### PR TITLE
Add buildpath to setup_entry

### DIFF
--- a/tools/setup_update/setup_entry.json
+++ b/tools/setup_update/setup_entry.json
@@ -4,6 +4,7 @@
 "in_use_for_parallel": false,
 "parallel_client_cnt": 0,
 "is_setup_free": true,
+"build_path":"",
 "nodes":[
     {
         "host": "eos-node-0",


### PR DESCRIPTION
Build path is added to setup_entry.json and default value is blank string.

Output:
(venv) C:\Users\532698\Documents\Cortxtest_workspace\cortx-test>python
Python 3.7.9 (tags/v3.7.9:13c94747c7, Aug 17 2020, 18:58:18) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.environ["TARGET"] = "automation"
>>> from config import CMN_CFG
>>> CMN_CFG["build_path"]      
''
>>>