### PR TITLE
EOS-19943 Robot changes for download folder

### DIFF
--- a/robot/resources/page_objects/settingsPage.robot
+++ b/robot/resources/page_objects/settingsPage.robot
@@ -4,7 +4,7 @@ Resource   ${EXECDIR}/resources/common/common.robot
 Variables  ${EXECDIR}/resources/common/element_locators.py
 
 *** Variables ***
-${Download_File_Path}  \root\Downloads\
+${Download_File_Path}  /root/Downloads
 ${default_file_name}  s3server.pem
 
 *** Keywords ***

--- a/robot/testsuites/gui/CFT/cft_testcases.robot
+++ b/robot/testsuites/gui/CFT/cft_testcases.robot
@@ -12,7 +12,6 @@ Resource    ${EXECDIR}/resources/page_objects/firmwareUpdatepage.robot
 Resource    ${EXECDIR}/resources/page_objects/preboardingPage.robot
 Resource    ${EXECDIR}/resources/common/common.robot
 Variables   ${EXECDIR}/resources/common/common_variables.py
-Variables   ${EXECDIR}/resources/common/common_variables.py
 
 Suite Setup  run keywords   check csm admin user status  ${url}  ${browser}  ${headless}
 ...  ${username}  ${password}
@@ -31,7 +30,7 @@ ${navigate_to_subpage}  False
 ${Sub_tab}  None
 ${username}
 ${password}
-${Download_File_Path}  \root\Downloads\
+${Download_File_Path}  /root/Downloads
 ${sw_version}  891
 
 *** Keywords ***
@@ -170,7 +169,7 @@ TEST-4932
     Verify Audit Log Generated
     Capture Page Screenshot  ${test_id}_CSM_audit_log_generated.png
     Download Audit Log  CSM  One day
-    Verify Audit Log Downloaded  ${Downlowait for page or element to loadad_File_Path}  csm
+    Verify Audit Log Downloaded  ${Download_File_Path}  csm
     Capture Page Screenshot  ${test_id}_CSM_audit_log_downloaded.png
     View Audit Log  S3  One day
     wait for page or element to load

--- a/robot/testsuites/gui/csm_users/csm_admin_user.robot
+++ b/robot/testsuites/gui/csm_users/csm_admin_user.robot
@@ -24,7 +24,7 @@ ${page name}  MANAGE_MENU_ID
 ${url}
 ${username}
 ${password}
-${Download_File_Path}  \root\Downloads\
+${Download_File_Path}  /root/Downloads
 ${server_file_name}  s3server.pem
 
 *** Keywords ***

--- a/robot/testsuites/gui/maintenance/auditlog.robot
+++ b/robot/testsuites/gui/maintenance/auditlog.robot
@@ -25,7 +25,7 @@ ${navigate_to_subpage}  False
 ${Sub_tab}  None
 ${username}
 ${password}
-${Download_File_Path}  \root\Downloads\
+${Download_File_Path}  /root/Downloads
 
 
 


### PR DESCRIPTION
Following six tests were failing
The patch content fix for those
TEST-11152
TEST-4871
TEST-9045
TEST-17997
TEST-13103
TEST-18332
Test execution with Patch at https://jts.seagate.com/browse/TEST-21446






-----
[View rendered README.md](https://github.com/ketanarlulkar/cortx-test/blob/EOS-19943-Robot-changes-for-download-folder/README.md)