### PR TITLE
Rename file name as it was conflicting pycache import in nightly run.

### DIFF
--- a/tests/di/test_di_durability.py
+++ b/tests/di/test_di_durability.py
@@ -39,8 +39,8 @@ from libs.s3.s3_multipart_test_lib import S3MultipartTestLib
 from libs.s3 import cortxcli_test_lib
 
 
-class TestDataDurability:
-    """Data Durability Test suite."""
+class TestDIDurability:
+    """DI Durability Test suite."""
 
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -225,7 +225,7 @@ class TestDataDurability:
             "Step 3: Verify range read (get) of an object whose metadata "
             "is corrupted")
         resp = self.s3_mp_test_obj.get_byte_range_of_object(
-            self.bucket_name, self.object_name, "1025", "8192")
+            self.bucket_name, self.object_name, 1025, 8192)
         assert_utils.assert_false(resp[0], resp[1])
         self.log.info(
             "Step 3: Range Read (get) of an object failed with an error")
@@ -417,7 +417,7 @@ class TestDataDurability:
             "Step 3: Verify range read (Get) of an object whose metadata"
             " is corrupted.")
         res = self.s3_mp_test_obj.get_byte_range_of_object(
-            self.bucket_name, self.object_name, "2025", "9216")
+            self.bucket_name, self.object_name, 2025, 9216)
         assert_utils.assert_false(res[0], res)
         self.log.info(
             "Step 3: Verified range read (Get) of an object whose metadata"


### PR DESCRIPTION
Hotfix to resolve nightly run import conflict.

**Error msg:**
import file mismatch:
imported module 'test_data_durability' has this __file__ attribute:
  /root/workspace/QA-Sanity-New-Pytest-Pipeline@2/tests/di/test_data_durability.py
which is not the same as the test file we want to collect:
  /root/workspace/QA-Sanity-New-Pytest-Pipeline@2/tests/s3/test_data_durability.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules

Signed-off-by: Dhananjay Dandapat <dhananjay.dandapat@seagate.com>