### PR TITLE
Hotfix against PR 437 to fix line continuation issue

### DIFF
--- a/config/prov/prov_test.yaml
+++ b/config/prov/prov_test.yaml
@@ -33,12 +33,12 @@ service_ports:
   s3: ["9443"]
   uds: ["5000"]
 build_url: "http://cortx-storage.colo.seagate.com/releases/cortx/github/{0}/centos-7.8.2003/{1}/"
-build_iso: "http://cortx-storage.colo.seagate.com/releases/cortx/github/{0}/centos-7.8.2003/{1}/ "
-           "iso/cortx-2.0.0-{2}-upgrade.iso"
-build_sig: "http://cortx-storage.colo.seagate.com/releases/cortx/github/{0}/centos-7.8.2003/{1}/ "
-           "iso/cortx-2.0.0-{2}-upgrade.iso.sig"
-build_key: "http://cortx-storage.colo.seagate.com/releases/cortx/github/{0}/centos-7.8.2003/{1}/ "
-           "cortx_iso/RPM-GPG-KEY-Seagate"
+build_iso: "http://cortx-storage.colo.seagate.com/releases/cortx/github/{0}/centos-7.8.2003/{1}/
+iso/cortx-2.0.0-{2}-upgrade.iso"
+build_sig: "http://cortx-storage.colo.seagate.com/releases/cortx/github/{0}/centos-7.8.2003/{1}/
+iso/cortx-2.0.0-{2}-upgrade.iso.sig"
+build_key: "http://cortx-storage.colo.seagate.com/releases/cortx/github/{0}/centos-7.8.2003/{1}/
+cortx_iso/RPM-GPG-KEY-Seagate"
 build_def: "last_successful_prod"
 cluster_start_msg: "Cluster start operation performed"
 confstore_list: ["host", "enclosure_id", "machine_id", "cluster_id"]


### PR DESCRIPTION
[root@ssc-vm-2837 cortx-test]# pytest tests/s3/test_multipart_upload.py -n 8 --target s3-VM-2837 --local True
ImportError while loading conftest '/root/VikasKumarC/cortx-test/conftest.py'.
conftest.py:54: in <module>
    from core.runner import LRUCache
core/runner.py:35: in <module>
    from config import CMN_CFG
config/__init__.py:95: in <module>
    PROV_CFG = configmanager.get_config_wrapper(fpath=PROV_TEST_CONFIG_PATH)
commons/configmanager.py:112: in get_config_wrapper
    config_details = get_config_yaml(fpath=kwargs['fpath'])
commons/configmanager.py:42: in get_config_yaml
    data = yaml.safe_load(fin)
/usr/local/lib/python3.7/site-packages/yaml/__init__.py:162: in safe_load
    return load(stream, SafeLoader)
/usr/local/lib/python3.7/site-packages/yaml/__init__.py:114: in load
    return loader.get_single_data()
/usr/local/lib/python3.7/site-packages/yaml/constructor.py:41: in get_single_data
    node = self.get_single_node()
/usr/local/lib/python3.7/site-packages/yaml/composer.py:36: in get_single_node
    document = self.compose_document()
/usr/local/lib/python3.7/site-packages/yaml/composer.py:55: in compose_document
    node = self.compose_node(None, None)
/usr/local/lib/python3.7/site-packages/yaml/composer.py:84: in compose_node
    node = self.compose_mapping_node(anchor)
/usr/local/lib/python3.7/site-packages/yaml/composer.py:127: in compose_mapping_node
    while not self.check_event(MappingEndEvent):
/usr/local/lib/python3.7/site-packages/yaml/parser.py:98: in check_event
    self.current_event = self.state()
/usr/local/lib/python3.7/site-packages/yaml/parser.py:439: in parse_block_mapping_key
    "expected <block end>, but found %r" % token.id, token.start_mark)
E   yaml.parser.ParserError: while parsing a block mapping
E     in "config/prov/prov_test.yaml", line 1, column 1
E   expected <block end>, but found '<scalar>'
E     in "config/prov/prov_test.yaml", line 37, column 12
