### PR TITLE
Eos 24621 adding sub category markers

### DIFF
--- a/tests/s3/test_all_users_bucket_acl.py
+++ b/tests/s3/test_all_users_bucket_acl.py
@@ -109,6 +109,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6094')
     @CTFailOn(error_handler)
     def test_375(self):
@@ -151,6 +152,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6092')
     @CTFailOn(error_handler)
     def test_376(self):
@@ -199,6 +201,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6090')
     @CTFailOn(error_handler)
     def test_377(self):
@@ -246,6 +249,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6088')
     @CTFailOn(error_handler)
     def test_378(self):
@@ -293,6 +297,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6086')
     @CTFailOn(error_handler)
     def test_379(self):
@@ -343,6 +348,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6084')
     @CTFailOn(error_handler)
     def test_380(self):
@@ -393,6 +399,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6082')
     @CTFailOn(error_handler)
     def test_381(self):
@@ -445,6 +452,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6080')
     @CTFailOn(error_handler)
     def test_382(self):
@@ -496,6 +504,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6078')
     @CTFailOn(error_handler)
     def test_383(self):
@@ -562,6 +571,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6076')
     @CTFailOn(error_handler)
     def test_384(self):
@@ -609,6 +619,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6074')
     @CTFailOn(error_handler)
     def test_385(self):
@@ -658,6 +669,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6072')
     @CTFailOn(error_handler)
     def test_386(self):
@@ -706,6 +718,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6070')
     @CTFailOn(error_handler)
     def test_387(self):
@@ -759,6 +772,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6068')
     @CTFailOn(error_handler)
     def test_388(self):
@@ -811,6 +825,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6066')
     @CTFailOn(error_handler)
     def test_389(self):
@@ -862,6 +877,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6064')
     @CTFailOn(error_handler)
     def test_390(self):
@@ -916,6 +932,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6062')
     @CTFailOn(error_handler)
     def test_391(self):
@@ -969,6 +986,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6060')
     @CTFailOn(error_handler)
     def test_392(self):
@@ -1023,6 +1041,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6058')
     @CTFailOn(error_handler)
     def test_393(self):
@@ -1069,6 +1088,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6056')
     @CTFailOn(error_handler)
     def test_394(self):
@@ -1122,6 +1142,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6054')
     @CTFailOn(error_handler)
     def test_395(self):
@@ -1176,6 +1197,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6052')
     @CTFailOn(error_handler)
     def test_396(self):
@@ -1229,6 +1251,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6050')
     @CTFailOn(error_handler)
     def test_397(self):
@@ -1284,6 +1307,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6048')
     @CTFailOn(error_handler)
     def test_398(self):
@@ -1338,6 +1362,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6044')
     @CTFailOn(error_handler)
     def test_399(self):
@@ -1391,6 +1416,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6042')
     @CTFailOn(error_handler)
     def test_400(self):
@@ -1443,6 +1469,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6040')
     @CTFailOn(error_handler)
     def test_401(self):
@@ -1497,6 +1524,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6038')
     @CTFailOn(error_handler)
     def test_402(self):
@@ -1551,6 +1579,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6036')
     @CTFailOn(error_handler)
     def test_403(self):
@@ -1601,6 +1630,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6033')
     @CTFailOn(error_handler)
     def test_404(self):
@@ -1655,6 +1685,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6031')
     @CTFailOn(error_handler)
     def test_405(self):
@@ -1707,6 +1738,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6029')
     @CTFailOn(error_handler)
     def test_406(self):
@@ -1760,6 +1792,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6026')
     @CTFailOn(error_handler)
     def test_407(self):
@@ -1810,6 +1843,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6024')
     @CTFailOn(error_handler)
     def test_408(self):
@@ -1864,6 +1898,7 @@ class TestAllUsersBucketAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags('TEST-6021')
     @CTFailOn(error_handler)
     def test_409(self):

--- a/tests/s3/test_all_users_object_acl.py
+++ b/tests/s3/test_all_users_object_acl.py
@@ -151,6 +151,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-6019")
     @CTFailOn(error_handler)
     def test_put_duplicate_object_without_auth_695(self):
@@ -181,6 +182,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-6016")
     @CTFailOn(error_handler)
     def test_delete_object_without_authentication_697(self):
@@ -208,6 +210,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-6014")
     @CTFailOn(error_handler)
     def test_read_object_acl_without_auth_698(self):
@@ -239,6 +242,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-6011")
     @CTFailOn(error_handler)
     def test_update_object_acl_without_auth_699(self):
@@ -271,6 +275,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-6009")
     @CTFailOn(error_handler)
     def test_put_duplicate_object_without_authentication_700(self):
@@ -302,6 +307,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-6006")
     @CTFailOn(error_handler)
     def test_delete_obj_without_auth_701(self):
@@ -330,6 +336,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-6004")
     @CTFailOn(error_handler)
     def test_read_obj_acl_without_auth_702(self):
@@ -359,6 +366,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-6002")
     @CTFailOn(error_handler)
     def test_update_obj_write_permission_without_auth_703(self):
@@ -389,6 +397,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-6001")
     @CTFailOn(error_handler)
     def test_put_duplicate_object_read_acp_704(self):
@@ -421,6 +430,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5970")
     @CTFailOn(error_handler)
     def test_get_object_without_authentication_read_permission_757(self):
@@ -450,6 +460,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5968")
     @CTFailOn(error_handler)
     def test_get_allusers_object_without_auth_758(self):
@@ -484,6 +495,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5999")
     @CTFailOn(error_handler)
     def test_get_object_read_acp_705(self):
@@ -519,6 +531,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5997")
     @CTFailOn(error_handler)
     def test_read_obj_without_auth_read_acp_706(self):
@@ -548,6 +561,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5995")
     @CTFailOn(error_handler)
     def test_update_obj_without_auth_read_acp_707(self):
@@ -579,6 +593,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5993")
     @CTFailOn(error_handler)
     def test_put_object_without_auth_write_acp_708(self):
@@ -609,6 +624,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5986")
     @CTFailOn(error_handler)
     def test_get_object_without_auth_write_acp_709(self):
@@ -641,6 +657,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5984")
     @CTFailOn(error_handler)
     def test_read_object_without_auth_write_acp_710(self):
@@ -673,6 +690,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5982")
     @CTFailOn(error_handler)
     def test_update_object_without_auth_write_acp_711(self):
@@ -699,6 +717,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5979")
     @CTFailOn(error_handler)
     def test_put_duplicate_object_full_control_712(self):
@@ -729,6 +748,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5977")
     @CTFailOn(error_handler)
     def test_get_object_without_auth_full_control_713(self):
@@ -758,6 +778,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5975")
     @CTFailOn(error_handler)
     def test_read_object_without_auth_full_control_714(self):
@@ -786,6 +807,7 @@ class TestAllUsersObjectAcl:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5973")
     @CTFailOn(error_handler)
     def test_update_object_without_auth_full_control_715(self):

--- a/tests/s3/test_audit_logs.py
+++ b/tests/s3/test_audit_logs.py
@@ -398,6 +398,7 @@ class TestAuditLogs:
         assert_utils.assert_true(result[0], result[1])
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8012')
     @CTFailOn(error_handler)
     def test_5248(self):
@@ -426,6 +427,7 @@ class TestAuditLogs:
                       "if we set audit logger policy to disabled")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8013')
     @CTFailOn(error_handler)
     def test_5236(self):
@@ -448,6 +450,7 @@ class TestAuditLogs:
             "Multipart upload with Syslog logger policy")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8014')
     @CTFailOn(error_handler)
     def test_5235(self):
@@ -469,6 +472,7 @@ class TestAuditLogs:
             "Object operations with syslog logger policy.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8015')
     @CTFailOn(error_handler)
     def test_5231(self):
@@ -490,6 +494,7 @@ class TestAuditLogs:
             "Bucket operations with syslog logger policy.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8016')
     @CTFailOn(error_handler)
     def test_5228(self):
@@ -511,6 +516,7 @@ class TestAuditLogs:
             "Object operations with log4cxx logger policy.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8018')
     @CTFailOn(error_handler)
     def test_5209(self):
@@ -532,6 +538,7 @@ class TestAuditLogs:
             "Bucket operations with log4cxx logger policy.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8017')
     @CTFailOn(error_handler)
     def test_5213(self):
@@ -554,6 +561,7 @@ class TestAuditLogs:
             "Multipart upload with log4cxx logger policy")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8010')
     @CTFailOn(error_handler)
     def test_6253(self):
@@ -602,6 +610,7 @@ class TestAuditLogs:
             " the audit server logs post any bucket operation.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8011')
     @CTFailOn(error_handler)
     def test_6255(self):
@@ -661,6 +670,7 @@ class TestAuditLogs:
             " the audit server logs post any object operation.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8726')
     @CTFailOn(error_handler)
     def test_5238(self):
@@ -708,6 +718,7 @@ class TestAuditLogs:
             "operations with 'rsyslog-tcp' logger policy")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8727')
     @CTFailOn(error_handler)
     def test_5240(self):
@@ -766,6 +777,7 @@ class TestAuditLogs:
             "operations with 'rsyslog-tcp' logger policy")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_audit_logs
     @pytest.mark.tags('TEST-8728')
     @CTFailOn(error_handler)
     def test_5246(self):

--- a/tests/s3/test_authserver_healthcheck.py
+++ b/tests/s3/test_authserver_healthcheck.py
@@ -123,6 +123,7 @@ class TestAuthServerHealthCheckAPI:
         return resp
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_auth_health
     @pytest.mark.tags('TEST-7577')
     @CTFailOn(error_handler)
     def test_authserver_response_on_health_check_enabled_1161(self):
@@ -145,6 +146,7 @@ class TestAuthServerHealthCheckAPI:
             "Ended: Test authserver response when health check is enabled")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_auth_health
     @pytest.mark.tags('TEST-7578')
     @CTFailOn(error_handler)
     def test_authserver_response_on_health_check_disabled_1164(self):

--- a/tests/s3/test_bucket_acl.py
+++ b/tests/s3/test_bucket_acl.py
@@ -135,6 +135,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5717")
     @CTFailOn(error_handler)
     def test_verify_get_bucket_acl_3012(self):
@@ -154,6 +155,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5719")
     @CTFailOn(error_handler)
     def test_verify_get_bucket_acl_3013(self):
@@ -171,6 +173,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5712")
     @CTFailOn(error_handler)
     def test_verify_get_bucket_acl_3014(self):
@@ -190,6 +193,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5718")
     @CTFailOn(error_handler)
     def test_verify_get_bucket_acl_3015(self):
@@ -220,6 +224,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5713")
     @CTFailOn(error_handler)
     def test_verify_get_bucket_acl_3016(self):
@@ -237,6 +242,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5720")
     @CTFailOn(error_handler)
     def test_delete_and_verify_bucket_acl_3017(self):
@@ -260,6 +266,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5716")
     @CTFailOn(error_handler)
     def test_verify_get_bucket_acl_3018(self):
@@ -297,6 +304,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5715")
     @CTFailOn(error_handler)
     def test_verify_get_bucket_acl_3019(self):
@@ -339,6 +347,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5714")
     @CTFailOn(error_handler)
     def test_verify_get_bucket_acl_3020(self):
@@ -395,6 +404,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5728")
     @CTFailOn(error_handler)
     def test_add_canned_acl_bucket_3527(self):
@@ -410,6 +420,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5727")
     @CTFailOn(error_handler)
     def test_add_canned_acl_bucket_3528(self):
@@ -425,6 +436,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5736")
     @CTFailOn(error_handler)
     def test_add_canned_acl_private_3529(self):
@@ -441,6 +453,7 @@ class TestBucketACL:
     @pytest.mark.skip("EOS-9547 Incorrect Header Grants ACL")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5737")
     @CTFailOn(error_handler)
     def test_add_canned_acl_private_3530(self):
@@ -457,6 +470,7 @@ class TestBucketACL:
     @pytest.mark.skip("EOS-9547 Incorrect Header Grants ACL")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5732")
     @CTFailOn(error_handler)
     def test_add_canned_acl_public_read_3531(self):
@@ -473,6 +487,7 @@ class TestBucketACL:
     @pytest.mark.skip("EOS-9547 Incorrect Header Grants ACL")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5731")
     @CTFailOn(error_handler)
     def test_add_canned_acl_public_read_3532(self):
@@ -489,6 +504,7 @@ class TestBucketACL:
     @pytest.mark.skip("EOS-9547 Incorrect Header Grants ACL")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5729")
     @CTFailOn(error_handler)
     def test_add_canned_acl_public_read_write_3533(self):
@@ -505,6 +521,7 @@ class TestBucketACL:
     @pytest.mark.skip("EOS-9547 Incorrect Header Grants ACL")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5730")
     @CTFailOn(error_handler)
     def test_add_canned_acl_public_read_write_3534(self):
@@ -520,6 +537,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5739")
     @CTFailOn(error_handler)
     def test_add_canned_acl_authenticate_read_3535(self):
@@ -536,6 +554,7 @@ class TestBucketACL:
     @pytest.mark.skip("EOS-9547 Incorrect Header Grants ACL")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5738")
     @CTFailOn(error_handler)
     def test_add_canned_acl_authenticate_read_3536(self):
@@ -551,6 +570,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5735")
     @CTFailOn(error_handler)
     def test_add_canned_acl_private_3537(self):
@@ -605,6 +625,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5733")
     @CTFailOn(error_handler)
     def test_add_canned_acl_private_3538(self):
@@ -659,6 +680,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5734")
     @CTFailOn(error_handler)
     def test_add_canned_acl_private_3539(self):
@@ -727,6 +749,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5726")
     @CTFailOn(error_handler)
     def test_add_canned_acl_authenticated_read_3577(self):
@@ -804,6 +827,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5724")
     @CTFailOn(error_handler)
     def test_apply_private_canned_acl_3578(self):
@@ -879,6 +903,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5722")
     @CTFailOn(error_handler)
     def test_grant_read_permission_acl_3579(self):
@@ -967,6 +992,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5721")
     @CTFailOn(error_handler)
     def test_perform_head_bucket_acl_3580(self):
@@ -987,6 +1013,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-5723")
     @CTFailOn(error_handler)
     def test_create_verify_default_acl_3581(self):
@@ -1007,6 +1034,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-8027")
     @CTFailOn(error_handler)
     def test_put_get_bucket_acl_312(self):
@@ -1028,6 +1056,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-8029")
     @CTFailOn(error_handler)
     def test_put_get_bucket_acl_313(self):
@@ -1063,6 +1092,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-8030")
     @CTFailOn(error_handler)
     def test_put_get_bucket_acl_431(self):
@@ -1099,6 +1129,7 @@ class TestBucketACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_acl
     @pytest.mark.tags("TEST-8712")
     @CTFailOn(error_handler)
     def test_full_control_acl_6423(self):

--- a/tests/s3/test_bucket_location.py
+++ b/tests/s3/test_bucket_location.py
@@ -71,6 +71,8 @@ class TestBucketLocation:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_location
+    @pytest.mark.s3_bucket_location
     @pytest.mark.tags("TEST-5310")
     @CTFailOn(error_handler)
     def test_get_bkt_loc_valid_bkt_272(self):
@@ -108,6 +110,7 @@ class TestBucketLocation:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_location
     @pytest.mark.tags("TEST-5311")
     @CTFailOn(error_handler)
     def test_get_bkt_loc_bkt_not_present_273(self):
@@ -133,6 +136,7 @@ class TestBucketLocation:
 
     # @pytest.mark.parallel This test cause worker crash in bucket policy test suites.
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_location
     @pytest.mark.tags("TEST-7419")
     @CTFailOn(error_handler)
     def test_cross_account_get_bkt_loc_with_permission_274(self):
@@ -212,6 +216,7 @@ class TestBucketLocation:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_location
     @pytest.mark.tags("TEST-5312")
     @CTFailOn(error_handler)
     def test_cross_account_get_bkt_loc_275(self):

--- a/tests/s3/test_bucket_policy.py
+++ b/tests/s3/test_bucket_policy.py
@@ -633,6 +633,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6102")
     @CTFailOn(error_handler)
     def test_254(self):
@@ -657,6 +658,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6101")
     @CTFailOn(error_handler)
     def test_260(self):
@@ -679,6 +681,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6100")
     @CTFailOn(error_handler)
     def test_261(self):
@@ -724,6 +727,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6099")
     @CTFailOn(error_handler)
     def test_262(self):
@@ -796,6 +800,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6079")
     @CTFailOn(error_handler)
     def test_642(self):
@@ -835,6 +840,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6077")
     @CTFailOn(error_handler)
     def test_644(self):
@@ -858,6 +864,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6075")
     @CTFailOn(error_handler)
     def test_646(self):
@@ -879,6 +886,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6073")
     @CTFailOn(error_handler)
     def test_658(self):
@@ -900,6 +908,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6071")
     @CTFailOn(error_handler)
     def test_659(self):
@@ -935,6 +944,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6069")
     @CTFailOn(error_handler)
     def test_679(self):
@@ -968,6 +978,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6067")
     @CTFailOn(error_handler)
     def test_680(self):
@@ -989,6 +1000,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6065")
     @CTFailOn(error_handler)
     def test_682(self):
@@ -1013,6 +1025,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6063")
     @CTFailOn(error_handler)
     def test_688(self):
@@ -1037,6 +1050,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6061")
     @CTFailOn(error_handler)
     def test_689(self):
@@ -1059,6 +1073,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6059")
     @CTFailOn(error_handler)
     def test_690(self):
@@ -1094,6 +1109,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6005")
     @CTFailOn(error_handler)
     def test_1300(self):
@@ -1135,6 +1151,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6003")
     @CTFailOn(error_handler)
     def test_1303(self):
@@ -1176,6 +1193,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6000")
     @CTFailOn(error_handler)
     def test_1307(self):
@@ -1216,6 +1234,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5998")
     @CTFailOn(error_handler)
     def test_1308(self):
@@ -1249,6 +1268,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6010")
     @CTFailOn(error_handler)
     def test_1294(self):
@@ -1296,6 +1316,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6007")
     @CTFailOn(error_handler)
     def test_1296(self):
@@ -1353,6 +1374,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6098")
     @CTFailOn(error_handler)
     def test_558(self):
@@ -1385,6 +1407,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6097")
     @CTFailOn(error_handler)
     def test_560(self):
@@ -1406,6 +1429,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6096")
     @CTFailOn(error_handler)
     def test_562(self):
@@ -1443,6 +1467,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6095")
     @CTFailOn(error_handler)
     def test_563(self):
@@ -1467,6 +1492,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6093")
     @CTFailOn(error_handler)
     def test_566(self):
@@ -1506,6 +1532,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6091")
     @CTFailOn(error_handler)
     def test_569(self):
@@ -1547,6 +1574,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6089")
     @CTFailOn(error_handler)
     def test_570(self):
@@ -1588,6 +1616,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6087")
     @CTFailOn(error_handler)
     def test_574(self):
@@ -1630,6 +1659,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6085")
     @CTFailOn(error_handler)
     def test_582(self):
@@ -1674,6 +1704,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6083")
     @CTFailOn(error_handler)
     def test_583(self):
@@ -1720,6 +1751,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6081")
     @CTFailOn(error_handler)
     def test_584(self):
@@ -1770,6 +1802,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6053")
     @CTFailOn(error_handler)
     def test_693(self):
@@ -1808,6 +1841,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6051")
     @CTFailOn(error_handler)
     def test_694(self):
@@ -1838,6 +1872,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6049")
     @CTFailOn(error_handler)
     def test_716(self):
@@ -1876,6 +1911,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6045")
     @CTFailOn(error_handler)
     def test_718(self):
@@ -1899,6 +1935,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6043")
     @CTFailOn(error_handler)
     def test_719(self):
@@ -1928,6 +1965,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6041")
     @CTFailOn(error_handler)
     def test_720(self):
@@ -1958,6 +1996,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6039")
     @CTFailOn(error_handler)
     def test_721(self):
@@ -1997,6 +2036,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6037")
     @CTFailOn(error_handler)
     def test_722(self):
@@ -2036,6 +2076,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6034")
     @CTFailOn(error_handler)
     def test_723(self):
@@ -2075,6 +2116,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6032")
     @CTFailOn(error_handler)
     def test_724(self):
@@ -2114,6 +2156,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6030")
     @CTFailOn(error_handler)
     def test_725(self):
@@ -2153,6 +2196,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6103")
     @CTFailOn(error_handler)
     def test_551(self):
@@ -2173,6 +2217,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6104")
     @CTFailOn(error_handler)
     def test_549(self):
@@ -2193,6 +2238,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6105")
     @CTFailOn(error_handler)
     def test_545(self):
@@ -2214,6 +2260,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6106")
     @CTFailOn(error_handler)
     def test_555(self):
@@ -2234,6 +2281,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6108")
     @CTFailOn(error_handler)
     def test_553(self):
@@ -2255,6 +2303,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6015")
     @CTFailOn(error_handler)
     def test_1080(self):
@@ -2290,6 +2339,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6017")
     @CTFailOn(error_handler)
     def test_1079(self):
@@ -2343,6 +2393,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6020")
     @CTFailOn(error_handler)
     def test_1078(self):
@@ -2384,6 +2435,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6022")
     @CTFailOn(error_handler)
     def test_1077(self):
@@ -2425,6 +2477,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6047")
     @CTFailOn(error_handler)
     def test_717(self):
@@ -2529,6 +2582,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6055")
     @CTFailOn(error_handler)
     def test_692(self):
@@ -2594,6 +2648,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6057")
     @CTFailOn(error_handler)
     def test_691(self):
@@ -2658,6 +2713,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5996")
     @CTFailOn(error_handler)
     def test_4134(self):
@@ -2713,6 +2769,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5994")
     @CTFailOn(error_handler)
     def test_4136(self):
@@ -2772,6 +2829,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5992")
     @CTFailOn(error_handler)
     def test_4143(self):
@@ -2827,6 +2885,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5985")
     @CTFailOn(error_handler)
     def test_4144(self):
@@ -2886,6 +2945,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5983")
     @CTFailOn(error_handler)
     def test_4145(self):
@@ -2941,6 +3001,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5980")
     @CTFailOn(error_handler)
     def test_4146(self):
@@ -3000,6 +3061,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5978")
     @CTFailOn(error_handler)
     def test_4147(self):
@@ -3055,6 +3117,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5976")
     @CTFailOn(error_handler)
     def test_4148(self):
@@ -3115,6 +3178,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6109")
     @CTFailOn(error_handler)
     def test_1190(self):
@@ -3158,6 +3222,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6111")
     @CTFailOn(error_handler)
     def test_1180(self):
@@ -3207,6 +3272,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6110")
     @CTFailOn(error_handler)
     def test_1191(self):
@@ -3240,6 +3306,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6112")
     @CTFailOn(error_handler)
     def test_1184(self):
@@ -3272,6 +3339,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6113")
     @CTFailOn(error_handler)
     def test_1171(self):
@@ -3313,6 +3381,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6114")
     @CTFailOn(error_handler)
     def test_1182(self):
@@ -3354,6 +3423,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6115")
     @CTFailOn(error_handler)
     def test_1110(self):
@@ -3399,6 +3469,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6116")
     @CTFailOn(error_handler)
     def test_1187(self):
@@ -3481,6 +3552,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6117")
     @CTFailOn(error_handler)
     def test_1166(self):
@@ -3519,6 +3591,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6118")
     @CTFailOn(error_handler)
     def test_1177(self):
@@ -3560,6 +3633,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6119")
     @CTFailOn(error_handler)
     def test_360(self):
@@ -3588,6 +3662,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6120")
     @CTFailOn(error_handler)
     def test_362(self):
@@ -3617,6 +3692,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6121")
     @CTFailOn(error_handler)
     def test_363(self):
@@ -3644,6 +3720,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6122")
     @CTFailOn(error_handler)
     def test_364(self):
@@ -3673,6 +3750,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6123")
     @CTFailOn(error_handler)
     def test_365(self):
@@ -3705,6 +3783,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6124")
     @CTFailOn(error_handler)
     def test_366(self):
@@ -3734,6 +3813,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6125")
     @CTFailOn(error_handler)
     def test_367(self):
@@ -3764,6 +3844,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6126")
     @CTFailOn(error_handler)
     def test_368(self):
@@ -3793,6 +3874,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6127")
     @CTFailOn(error_handler)
     def test_369(self):
@@ -3824,6 +3906,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6128")
     @CTFailOn(error_handler)
     def test_370(self):
@@ -3856,6 +3939,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6129")
     @CTFailOn(error_handler)
     def test_371(self):
@@ -3893,6 +3977,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6131")
     @CTFailOn(error_handler)
     def test_372(self):
@@ -3939,6 +4024,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6132")
     @CTFailOn(error_handler)
     def test_373(self):
@@ -3979,6 +4065,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6133")
     @CTFailOn(error_handler)
     def test_374(self):
@@ -4019,6 +4106,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6134")
     @CTFailOn(error_handler)
     def test_1188(self):
@@ -4068,6 +4156,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6136")
     @CTFailOn(error_handler)
     def test_1174(self):
@@ -4103,6 +4192,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6138")
     @CTFailOn(error_handler)
     def test_1185(self):
@@ -4136,6 +4226,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6140")
     @CTFailOn(error_handler)
     def test_1186(self):
@@ -4176,6 +4267,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6142")
     @CTFailOn(error_handler)
     def test_1114(self):
@@ -4219,6 +4311,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6144")
     @CTFailOn(error_handler)
     def test_1169(self):
@@ -4263,6 +4356,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6146")
     @CTFailOn(error_handler)
     def test_1167(self):
@@ -4301,6 +4395,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6147")
     @CTFailOn(error_handler)
     def test_1113(self):
@@ -4329,6 +4424,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6148")
     @CTFailOn(error_handler)
     def test_1116(self):
@@ -4359,6 +4455,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6012")
     @CTFailOn(error_handler)
     def test_1109(self):
@@ -4412,6 +4509,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7692")
     @CTFailOn(error_handler)
     def test_270(self):
@@ -4493,6 +4591,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7693")
     @CTFailOn(error_handler)
     def test_271(self):
@@ -4556,6 +4655,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5974")
     @CTFailOn(error_handler)
     def test_4156(self):
@@ -4605,6 +4705,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5972")
     @CTFailOn(error_handler)
     def test_4161(self):
@@ -4656,6 +4757,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5957")
     @CTFailOn(error_handler)
     def test_4173(self):
@@ -4706,6 +4808,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5969")
     @CTFailOn(error_handler)
     def test_4170(self):
@@ -4766,6 +4869,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-5955")
     @CTFailOn(error_handler)
     def test_4183(self):
@@ -4816,6 +4920,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6027")
     @CTFailOn(error_handler)
     def test_1069(self):
@@ -4839,6 +4944,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6025")
     @CTFailOn(error_handler)
     def test_1075(self):
@@ -4867,6 +4973,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7694")
     @CTFailOn(error_handler)
     def test_4502(self):
@@ -4894,6 +5001,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7695")
     @CTFailOn(error_handler)
     def test_4504(self):
@@ -4922,6 +5030,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7696")
     @CTFailOn(error_handler)
     def test_4505(self):
@@ -4950,6 +5059,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7697")
     @CTFailOn(error_handler)
     def test_4506(self):
@@ -4978,6 +5088,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7698")
     @CTFailOn(error_handler)
     def test_4507(self):
@@ -5006,6 +5117,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7699")
     @CTFailOn(error_handler)
     def test_4508(self):
@@ -5033,6 +5145,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7700")
     @CTFailOn(error_handler)
     def test_4509(self):
@@ -5060,6 +5173,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7701")
     @CTFailOn(error_handler)
     def test_4510(self):
@@ -5087,6 +5201,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7702")
     @CTFailOn(error_handler)
     def test_4511(self):
@@ -5114,6 +5229,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7703")
     @CTFailOn(error_handler)
     def test_4512(self):
@@ -5141,6 +5257,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7704")
     @CTFailOn(error_handler)
     def test_4513(self):
@@ -5168,6 +5285,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7705")
     @CTFailOn(error_handler)
     def test_4514(self):
@@ -5195,6 +5313,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7706")
     @CTFailOn(error_handler)
     def test_4515(self):
@@ -5222,6 +5341,7 @@ class TestBucketPolicy:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7707")
     @CTFailOn(error_handler)
     def test_4516(self):
@@ -5250,6 +5370,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7708")
     @CTFailOn(error_handler)
     def test_4517(self):
@@ -5277,6 +5398,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6929")
     @CTFailOn(error_handler)
     def test_5770(self):
@@ -5303,6 +5425,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6930")
     @CTFailOn(error_handler)
     def test_5831(self):
@@ -5329,6 +5452,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6931")
     @CTFailOn(error_handler)
     def test_5832(self):
@@ -5355,6 +5479,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6932")
     @CTFailOn(error_handler)
     def test_5778(self):
@@ -5381,6 +5506,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6933")
     @CTFailOn(error_handler)
     def test_5740(self):
@@ -5407,6 +5533,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6934")
     @CTFailOn(error_handler)
     def test_5751(self):
@@ -5433,6 +5560,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6935")
     @CTFailOn(error_handler)
     def test_5773(self):
@@ -5459,6 +5587,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6938")
     @CTFailOn(error_handler)
     def test_5764(self):
@@ -5504,6 +5633,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6939")
     @CTFailOn(error_handler)
     def test_5758(self):
@@ -5530,6 +5660,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6970")
     @CTFailOn(error_handler)
     def test_5925(self):
@@ -5577,6 +5708,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6971")
     @CTFailOn(error_handler)
     def test_5926(self):
@@ -5603,6 +5735,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6972")
     @CTFailOn(error_handler)
     def test_5937(self):
@@ -5629,6 +5762,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7709")
     @CTFailOn(error_handler)
     def test_1902(self):
@@ -5682,6 +5816,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7710")
     @CTFailOn(error_handler)
     def test_1903(self):
@@ -5735,6 +5870,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7711")
     @CTFailOn(error_handler)
     def test_1904(self):
@@ -5792,6 +5928,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7712")
     @CTFailOn(error_handler)
     def test_1908(self):
@@ -5848,6 +5985,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6979")
     @CTFailOn(error_handler)
     def test_4937(self):
@@ -5912,6 +6050,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6980")
     @CTFailOn(error_handler)
     def test_4939(self):
@@ -5978,6 +6117,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6981")
     @CTFailOn(error_handler)
     def test_4940(self):
@@ -6047,6 +6187,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6982")
     @CTFailOn(error_handler)
     def test_4941(self):
@@ -6112,6 +6253,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6983")
     @CTFailOn(error_handler)
     def test_4942(self):
@@ -6176,6 +6318,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6984")
     @CTFailOn(error_handler)
     def test_4943(self):
@@ -6242,6 +6385,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6985")
     @CTFailOn(error_handler)
     def test_4944(self):
@@ -6307,6 +6451,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6986")
     @CTFailOn(error_handler)
     def test_4945(self):
@@ -6372,6 +6517,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6973")
     @CTFailOn(error_handler)
     def test_5449(self):
@@ -6435,6 +6581,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6974")
     @CTFailOn(error_handler)
     def test_5471(self):
@@ -6501,6 +6648,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6975")
     @CTFailOn(error_handler)
     def test_5473(self):
@@ -6565,6 +6713,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6976")
     @CTFailOn(error_handler)
     def test_5481(self):
@@ -6630,6 +6779,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-6977")
     @CTFailOn(error_handler)
     def test_5490(self):
@@ -6670,6 +6820,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-18450")
     @CTFailOn(error_handler)
     def test_6550(self):
@@ -6751,6 +6902,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-18451")
     @CTFailOn(error_handler)
     def test_6553(self):
@@ -6870,6 +7022,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7516")
     @CTFailOn(error_handler)
     def test_6693(self):
@@ -6926,6 +7079,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7517")
     @CTFailOn(error_handler)
     def test_6703(self):
@@ -6986,6 +7140,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7518")
     @CTFailOn(error_handler)
     def test_6704(self):
@@ -7046,6 +7201,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7519")
     @CTFailOn(error_handler)
     def test_6760(self):
@@ -7106,6 +7262,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7520")
     @CTFailOn(error_handler)
     def test_6761(self):
@@ -7156,6 +7313,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7521")
     @CTFailOn(error_handler)
     def test_6763(self):
@@ -7206,6 +7364,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7522")
     @CTFailOn(error_handler)
     def test_6764(self):
@@ -7266,6 +7425,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7523")
     @CTFailOn(error_handler)
     def test_6765(self):
@@ -7326,6 +7486,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7524")
     @CTFailOn(error_handler)
     def test_6766(self):
@@ -7385,6 +7546,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7525")
     @CTFailOn(error_handler)
     def test_6767(self):
@@ -7445,6 +7607,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7526")
     @CTFailOn(error_handler)
     def test_6768(self):
@@ -7505,6 +7668,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7527")
     @CTFailOn(error_handler)
     def test_6769(self):
@@ -7564,6 +7728,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7528")
     @CTFailOn(error_handler)
     def test_6770(self):
@@ -7624,6 +7789,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7611")
     @CTFailOn(error_handler)
     def test_5921(self):
@@ -7641,6 +7807,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7612")
     @CTFailOn(error_handler)
     def test_5211(self):
@@ -7708,6 +7875,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7613")
     @CTFailOn(error_handler)
     def test_5210(self):
@@ -7784,6 +7952,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7614")
     @CTFailOn(error_handler)
     def test_5206(self):
@@ -7825,6 +7994,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7615")
     @CTFailOn(error_handler)
     def test_5212(self):
@@ -7946,6 +8116,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7616")
     @CTFailOn(error_handler)
     def test_5214(self):
@@ -8029,6 +8200,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7617")
     @CTFailOn(error_handler)
     def test_5215(self):
@@ -8141,6 +8313,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7637")
     @CTFailOn(error_handler)
     def test_6771(self):
@@ -8201,6 +8374,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7638")
     @CTFailOn(error_handler)
     def test_6772(self):
@@ -8256,6 +8430,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7639")
     @CTFailOn(error_handler)
     def test_6773(self):
@@ -8302,6 +8477,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7640")
     @CTFailOn(error_handler)
     def test_6774(self):
@@ -8347,6 +8523,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7641")
     @CTFailOn(error_handler)
     def test_6775(self):
@@ -8389,6 +8566,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7642")
     @CTFailOn(error_handler)
     def test_6776(self):
@@ -8447,6 +8625,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7643")
     @CTFailOn(error_handler)
     def test_6777(self):
@@ -8505,6 +8684,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7644")
     @CTFailOn(error_handler)
     def test_6779(self):
@@ -8558,6 +8738,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7645")
     @CTFailOn(error_handler)
     def test_6783(self):
@@ -8602,6 +8783,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7646")
     @CTFailOn(error_handler)
     def test_6787(self):
@@ -8643,6 +8825,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7648")
     @CTFailOn(error_handler)
     def test_6788(self):
@@ -8684,6 +8867,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7650")
     @CTFailOn(error_handler)
     def test_6790(self):
@@ -8741,6 +8925,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7651")
     @CTFailOn(error_handler)
     def test_6791(self):
@@ -8798,6 +8983,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8044")
     @CTFailOn(error_handler)
     def test_6792(self):
@@ -8856,6 +9042,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8043")
     @CTFailOn(error_handler)
     def test_6762(self):
@@ -8945,6 +9132,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8041")
     @CTFailOn(error_handler)
     def test_6707(self):
@@ -9026,6 +9214,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8042")
     @CTFailOn(error_handler)
     def test_6708(self):
@@ -9106,6 +9295,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8045")
     @CTFailOn(error_handler)
     def test_7051(self):
@@ -9222,6 +9412,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8046")
     @CTFailOn(error_handler)
     def test_7052(self):
@@ -9288,6 +9479,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8047")
     @CTFailOn(error_handler)
     def test_7054(self):
@@ -9389,6 +9581,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8048")
     @CTFailOn(error_handler)
     def test_7055(self):
@@ -9490,6 +9683,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8049")
     @CTFailOn(error_handler)
     def test_7056(self):
@@ -9559,6 +9753,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8050")
     @CTFailOn(error_handler)
     def test_7057(self):
@@ -9640,6 +9835,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8051")
     @CTFailOn(error_handler)
     def test_7058(self):
@@ -9706,6 +9902,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8052")
     @CTFailOn(error_handler)
     def test_7059(self):
@@ -9782,6 +9979,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8037")
     @CTFailOn(error_handler)
     def test_5134(self):
@@ -9874,6 +10072,7 @@ _date."""
     # fixed.
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-10359")
     @CTFailOn(error_handler)
     def test_7053(self):
@@ -9946,6 +10145,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-18452")
     @CTFailOn(error_handler)
     def test_6554(self):
@@ -10074,6 +10274,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8038")
     @CTFailOn(error_handler)
     def test_5136(self):
@@ -10182,6 +10383,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-18453")
     @CTFailOn(error_handler)
     def test_6555(self):
@@ -10328,6 +10530,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8040")
     @CTFailOn(error_handler)
     def test_5138(self):
@@ -10428,6 +10631,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8039")
     @CTFailOn(error_handler)
     def test_5121(self):
@@ -10530,6 +10734,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-18454")
     @CTFailOn(error_handler)
     def test_6557(self):
@@ -10587,6 +10792,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8036")
     @CTFailOn(error_handler)
     def test_5118(self):
@@ -10688,6 +10894,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7939")
     @CTFailOn(error_handler)
     def test_5115(self):
@@ -10767,6 +10974,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7938")
     @CTFailOn(error_handler)
     def test_5114(self):
@@ -10848,6 +11056,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7937")
     @CTFailOn(error_handler)
     def test_5110(self):
@@ -10930,6 +11139,7 @@ _date."""
     # already raised for this - EOS-7062
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7940")
     @CTFailOn(error_handler)
     def test_5116(self):
@@ -11015,6 +11225,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7941")
     @CTFailOn(error_handler)
     def test_5117(self):
@@ -11096,6 +11307,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7943")
     @CTFailOn(error_handler)
     def test_5120(self):
@@ -11194,6 +11406,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7945")
     @CTFailOn(error_handler)
     def test_5122(self):
@@ -11292,6 +11505,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7946")
     @CTFailOn(error_handler)
     def test_5123(self):
@@ -11370,6 +11584,7 @@ _date."""
     # already raised for this - EOS-7062
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7947")
     @CTFailOn(error_handler)
     def test_5126(self):
@@ -11444,6 +11659,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7936")
     @CTFailOn(error_handler)
     def test_5124(self):
@@ -11523,6 +11739,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7944")
     @CTFailOn(error_handler)
     def test_5125(self):
@@ -11603,6 +11820,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-7942")
     @CTFailOn(error_handler)
     def test_5137(self):
@@ -11703,6 +11921,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9031")
     @CTFailOn(error_handler)
     def test_6967(self):
@@ -11757,6 +11976,7 @@ _date."""
     # Defect raised for this test cases - EOS-7062
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9033")
     @CTFailOn(error_handler)
     def test_6969(self):
@@ -11819,6 +12039,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9038")
     @CTFailOn(error_handler)
     def test_6991(self):
@@ -11883,6 +12104,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9039")
     @CTFailOn(error_handler)
     def test_6992(self):
@@ -11946,6 +12168,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9041")
     @CTFailOn(error_handler)
     def test_6999(self):
@@ -12019,6 +12242,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9042")
     @CTFailOn(error_handler)
     def test_7000(self):
@@ -12089,6 +12313,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9032")
     @CTFailOn(error_handler)
     def test_6968(self):
@@ -12155,6 +12380,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9034")
     @CTFailOn(error_handler)
     def test_6978(self):
@@ -12222,6 +12448,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9035")
     @CTFailOn(error_handler)
     def test_6987(self):
@@ -12278,6 +12505,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9036")
     @CTFailOn(error_handler)
     def test_6988(self):
@@ -12347,6 +12575,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9037")
     @CTFailOn(error_handler)
     def test_6990(self):
@@ -12409,6 +12638,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9040")
     @CTFailOn(error_handler)
     def test_6997(self):
@@ -12484,6 +12714,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8721")
     @CTFailOn(error_handler)
     def test_1295(self):
@@ -12544,6 +12775,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8722")
     @CTFailOn(error_handler)
     def test_1297(self):
@@ -12591,6 +12823,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8720")
     @CTFailOn(error_handler)
     def test_4598(self):
@@ -12629,6 +12862,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8702")
     @CTFailOn(error_handler)
     def test_7001(self):
@@ -12667,6 +12901,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8703")
     @CTFailOn(error_handler)
     def test_7002(self):
@@ -12714,6 +12949,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8704")
     @CTFailOn(error_handler)
     def test_7009(self):
@@ -12756,6 +12992,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8705")
     @CTFailOn(error_handler)
     def test_7014(self):
@@ -12802,6 +13039,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8706")
     @CTFailOn(error_handler)
     def test_7015(self):
@@ -12859,6 +13097,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8707")
     @CTFailOn(error_handler)
     def test_7016(self):
@@ -12902,6 +13141,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8708")
     @CTFailOn(error_handler)
     def test_7849(self):
@@ -12959,6 +13199,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8709")
     @CTFailOn(error_handler)
     def test_7850(self):
@@ -13011,6 +13252,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8710")
     @CTFailOn(error_handler)
     def test_7851(self):
@@ -13062,6 +13304,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-8711")
     @CTFailOn(error_handler)
     def test_7852(self):
@@ -13108,6 +13351,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9661")
     @CTFailOn(error_handler)
     def test_6966(self):
@@ -13154,6 +13398,7 @@ _date."""
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_policy
     @pytest.mark.tags("TEST-9662")
     @CTFailOn(error_handler)
     def test_6923(self):

--- a/tests/s3/test_bucket_tagging.py
+++ b/tests/s3/test_bucket_tagging.py
@@ -70,6 +70,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5514")
     @CTFailOn(error_handler)
     def test_2432(self):
@@ -110,6 +111,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5517")
     @CTFailOn(error_handler)
     def test_2433(self):
@@ -149,6 +151,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5519")
     @CTFailOn(error_handler)
     def test_2434(self):
@@ -194,6 +197,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5533")
     @CTFailOn(error_handler)
     def test_2435(self):
@@ -236,6 +240,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5534")
     @CTFailOn(error_handler)
     def test_2436(self):
@@ -277,6 +282,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5535")
     @CTFailOn(error_handler)
     def test_2437(self):
@@ -322,6 +328,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5536")
     @CTFailOn(error_handler)
     def test_2438(self):
@@ -368,6 +375,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5528")
     @CTFailOn(error_handler)
     def test_2439(self):
@@ -410,6 +418,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5529")
     @CTFailOn(error_handler)
     def test_2440(self):
@@ -448,6 +457,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5521")
     @CTFailOn(error_handler)
     def test_2441(self):
@@ -492,6 +502,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5520")
     @CTFailOn(error_handler)
     def test_2442(self):
@@ -535,6 +546,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5526")
     @CTFailOn(error_handler)
     def test_2443(self):
@@ -578,6 +590,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5527")
     @CTFailOn(error_handler)
     def test_2444(self):
@@ -616,6 +629,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5524")
     @CTFailOn(error_handler)
     def test_2445(self):
@@ -655,6 +669,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5531")
     @CTFailOn(error_handler)
     def test_2446(self):
@@ -689,6 +704,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5512")
     @CTFailOn(error_handler)
     def test_2447(self):
@@ -733,6 +749,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5530")
     @CTFailOn(error_handler)
     def test_2448(self):
@@ -767,6 +784,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5523")
     @CTFailOn(error_handler)
     def test_2449(self):
@@ -872,6 +890,7 @@ class TestBucketTagging:
     # Raised bug EOS-2528, Uncomment when fixed
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5522")
     @CTFailOn(error_handler)
     def test_2450(self):
@@ -904,6 +923,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5513")
     @CTFailOn(error_handler)
     def test_2451(self):
@@ -933,6 +953,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5516")
     @CTFailOn(error_handler)
     def test_2452(self):
@@ -974,6 +995,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_tags
     @pytest.mark.tags("TEST-5518")
     @CTFailOn(error_handler)
     def test_2453(self):

--- a/tests/s3/test_bucket_workflow_operations.py
+++ b/tests/s3/test_bucket_workflow_operations.py
@@ -80,6 +80,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5463")
     @CTFailOn(error_handler)
     def test_name_lowercase_letters_1975(self):
@@ -104,6 +105,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5469")
     @CTFailOn(error_handler)
     def test_name_constains_alphanumeric_1976(self):
@@ -127,6 +129,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5467")
     @CTFailOn(error_handler)
     def test_bucketname_2to63_chars_long_1977(self):
@@ -163,6 +166,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5468")
     @CTFailOn(error_handler)
     def test_name_lessthan3chars_morethan63chars_1978(self):
@@ -190,6 +194,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5464")
     @CTFailOn(error_handler)
     def test_name_nouppercase_1979(self):
@@ -213,6 +218,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5465")
     @CTFailOn(error_handler)
     def test_name_with_underscores_1980(self):
@@ -234,6 +240,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5462")
     @CTFailOn(error_handler)
     def test_name_special_characters_1981(self):
@@ -267,6 +274,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5466")
     @CTFailOn(error_handler)
     def test_name_formatting_1982(self):
@@ -290,6 +298,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5459")
@@ -317,6 +326,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5460")
     @CTFailOn(error_handler)
     def test_create_multiple_buckets_2040(self):
@@ -342,6 +352,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5461")
     @CTFailOn(error_handler)
     def test_duplicate_name_2043(self):
@@ -372,6 +383,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5447")
     @CTFailOn(error_handler)
     def test_max_bucket_creation_2044(self):
@@ -403,6 +415,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5457")
@@ -445,6 +458,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5458")
     @CTFailOn(error_handler)
     def test_forcefully_delete_objects_2046(self):
@@ -478,6 +492,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5455")
@@ -504,6 +519,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5454")
     @CTFailOn(error_handler)
     def test_delete_multiple_buckets_2048(self):
@@ -532,6 +548,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5456")
     @CTFailOn(error_handler)
     def test_delete_non_existing_bucket_2049(self):
@@ -552,6 +569,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5452")
@@ -595,6 +613,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5448")
     @CTFailOn(error_handler)
     def test_disk_usages_verification_2051(self):
@@ -632,6 +651,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5453")
     @CTFailOn(error_handler)
     def test_head_non_existing_bucket_2055(self):
@@ -650,6 +670,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5445")
     @CTFailOn(error_handler)
     def test_verify_head_bucket_2056(self):
@@ -680,6 +701,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5446")
     @CTFailOn(error_handler)
     def test_verify_list_bucket_2057(self):
@@ -707,6 +729,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-5450")
     @CTFailOn(error_handler)
     def test_bucket_location_verification_2059(self):
@@ -728,6 +751,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-8031")
     @CTFailOn(error_handler)
     def test_delete_multiobjects_432(self):
@@ -771,6 +795,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-8032")
     @CTFailOn(error_handler)
     def test_delete_non_existing_multibuckets_433(self):
@@ -805,6 +830,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-8033")
     @CTFailOn(error_handler)
     def test_delete_object_without_permission_434(self):
@@ -869,6 +895,7 @@ class TestBucketWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_ops
     @pytest.mark.tags("TEST-8035")
     @CTFailOn(error_handler)
     def test_delete_multiple_objects_without_permission_435(self):

--- a/tests/s3/test_copy_object.py
+++ b/tests/s3/test_copy_object.py
@@ -280,6 +280,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19841")
     @CTFailOn(error_handler)
     def test_19841(self):
@@ -354,6 +355,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19842")
     @CTFailOn(error_handler)
     def test_19842(self):
@@ -430,6 +432,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19843")
     @CTFailOn(error_handler)
     def test_19843(self):
@@ -515,6 +518,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19844")
     @pytest.mark.parametrize("object_size", ["5GB", "2GB"])
     def test_19844(self, object_size):
@@ -587,6 +591,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19846")
     @CTFailOn(error_handler)
     def test_19846(self):
@@ -646,6 +651,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19847")
     @CTFailOn(error_handler)
     def test_19847(self):
@@ -740,6 +746,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19848")
     @CTFailOn(error_handler)
     def test_19848(self):
@@ -833,6 +840,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19849")
     @CTFailOn(error_handler)
     def test_19849(self):
@@ -919,6 +927,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19850")
     @CTFailOn(error_handler)
     def test_19850(self):
@@ -981,6 +990,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19851")
     @CTFailOn(error_handler)
     def test_19851(self):
@@ -1063,6 +1073,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19891")
     @CTFailOn(error_handler)
     def test_19891(self):
@@ -1147,6 +1158,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19892")
     @CTFailOn(error_handler)
     def test_19892(self):
@@ -1217,6 +1229,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19893")
     @CTFailOn(error_handler)
     def test_19893(self):
@@ -1302,6 +1315,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19894")
     @CTFailOn(error_handler)
     def test_19894(self):
@@ -1372,6 +1386,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19895")
     @CTFailOn(error_handler)
     def test_19895(self):
@@ -1452,6 +1467,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19896")
     @CTFailOn(error_handler)
     def test_19896(self):
@@ -1528,6 +1544,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19897")
     @CTFailOn(error_handler)
     def test_19897(self):
@@ -1589,6 +1606,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19898")
     @CTFailOn(error_handler)
     def test_19898(self):
@@ -1655,6 +1673,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19899")
     @CTFailOn(error_handler)
     def test_19899(self):
@@ -1735,6 +1754,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-19900")
     @pytest.mark.parametrize("object_name",
                              ["new% (1234) ::#$$^**", "cp-object"])
@@ -1838,6 +1858,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-16899")
     @CTFailOn(error_handler)
     def test_16899(self):
@@ -1888,6 +1909,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-17110")
     @CTFailOn(error_handler)
     def test_17110(self):
@@ -1957,6 +1979,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-22283")
     @CTFailOn(error_handler)
     def test_22283(self):
@@ -2031,6 +2054,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-22287")
     @CTFailOn(error_handler)
     def test_22287(self):
@@ -2124,6 +2148,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-22292")
     @CTFailOn(error_handler)
     def test_22292(self):
@@ -2257,6 +2282,7 @@ class TestCopyObjects:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_copy
     @pytest.mark.tags("TEST-22299")
     @CTFailOn(error_handler)
     def test_22299(self):

--- a/tests/s3/test_data_durability.py
+++ b/tests/s3/test_data_durability.py
@@ -154,6 +154,7 @@ class TestDataDurability:
         return chksm_before_put_obj
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_durability
     @pytest.mark.tags('TEST-8005')
     @pytest.mark.parametrize("service", [const.S3AUTHSERVER])
     def test_no_data_loss_in_case_service_restart_4232(self, service):
@@ -206,6 +207,7 @@ class TestDataDurability:
             "ENDED: Test NO data loss in case of service restart- %s", service)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_durability
     @pytest.mark.tags('TEST-8006')
     @CTFailOn(error_handler)
     def test_no_data_loss_in_case_haproxy_restart_4233(self):
@@ -214,6 +216,7 @@ class TestDataDurability:
 
     @pytest.mark.skip(reason="Will be taken after F-45H.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_durability
     @pytest.mark.tags('TEST-8009')
     @CTFailOn(error_handler)
     def test_no_data_loss_in_case_account_cred_change_4238(self):
@@ -298,6 +301,7 @@ class TestDataDurability:
             "ENDED: Test NO data loss in case of account credentials change")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_durability
     @pytest.mark.tags('TEST-8004')
     @CTFailOn(error_handler)
     def test_no_data_loss_corruption_in_case_s3server_restart_4231(self):
@@ -340,6 +344,7 @@ class TestDataDurability:
 
     @pytest.mark.skip(reason="Restarting cluster make avalanche effect.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_durability
     @pytest.mark.tags('TEST-8007')
     @CTFailOn(error_handler)
     def test_no_data_loss_in_case_motr_restart_4234(self):

--- a/tests/s3/test_data_path_validation.py
+++ b/tests/s3/test_data_path_validation.py
@@ -170,6 +170,7 @@ class TestDataPathValidation:
                 resp[1]), f"S3 IO's failed: {resp[1]}")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8735')
     @pytest.mark.parametrize("obj_size, block_size", [(1, 1)])
     def test_1696(self, obj_size, block_size):
@@ -185,6 +186,7 @@ class TestDataPathValidation:
             obj_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8736')
     @pytest.mark.parametrize("obj_size, block_size", [(1000, 1)])
     def test_1697(self, obj_size, block_size):
@@ -192,6 +194,7 @@ class TestDataPathValidation:
         self.test_1696(obj_size, block_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8737')
     @pytest.mark.parametrize("obj_size, block_size", [(1, "1M")])
     def test_1698(self, obj_size, block_size):
@@ -207,6 +210,7 @@ class TestDataPathValidation:
             obj_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8738')
     @pytest.mark.parametrize("obj_size, block_size", [(10, "1M")])
     def test_1699(self, obj_size, block_size):
@@ -214,6 +218,7 @@ class TestDataPathValidation:
         self.test_1698(obj_size, block_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8739')
     @pytest.mark.parametrize("obj_size, block_size", [(100, "1M")])
     def test_1700(self, obj_size, block_size):
@@ -221,6 +226,7 @@ class TestDataPathValidation:
         self.test_1698(obj_size, block_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8740')
     @pytest.mark.parametrize("obj_size, block_size", [(1000, "1M")])
     def test_1701(self, obj_size, block_size):
@@ -228,6 +234,7 @@ class TestDataPathValidation:
         self.test_1698(obj_size, block_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8741')
     @pytest.mark.parametrize("obj_size, block_size", [(10000, "1M")])
     def test_1702(self, obj_size, block_size):
@@ -235,6 +242,7 @@ class TestDataPathValidation:
         self.test_1698(obj_size, block_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8742')
     @pytest.mark.parametrize("obj_size, block_size", [(1, 1)])
     def test_1703(self, obj_size, block_size):
@@ -251,6 +259,7 @@ class TestDataPathValidation:
             obj_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8743')
     @pytest.mark.parametrize("obj_size, block_size", [(1000, 1)])
     def test_1704(self, obj_size, block_size):
@@ -258,6 +267,7 @@ class TestDataPathValidation:
         self.test_1703(obj_size, block_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8744')
     @pytest.mark.parametrize("obj_size, block_size", [(1, "1M")])
     def test_1705(self, obj_size, block_size):
@@ -274,6 +284,7 @@ class TestDataPathValidation:
             obj_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8745')
     @pytest.mark.parametrize("obj_size, block_size", [(10, "1M")])
     def test_1706(self, obj_size, block_size):
@@ -281,6 +292,7 @@ class TestDataPathValidation:
         self.test_1705(obj_size, block_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8746')
     @pytest.mark.parametrize("obj_size, block_size", [(100, "1M")])
     def test_1707(self, obj_size, block_size):
@@ -288,6 +300,7 @@ class TestDataPathValidation:
         self.test_1705(obj_size, block_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8729')
     @pytest.mark.parametrize("obj_size, block_size", [(1000, "1M")])
     def test_1708(self, obj_size, block_size):
@@ -295,6 +308,7 @@ class TestDataPathValidation:
         self.test_1705(obj_size, block_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8730')
     @pytest.mark.parametrize("obj_size, block_size", [(10000, "1M")])
     def test_1709(self, obj_size, block_size):
@@ -302,6 +316,7 @@ class TestDataPathValidation:
         self.test_1705(obj_size, block_size)
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8731')
     @pytest.mark.parametrize("obj_size, requests",
                              [("8Mb", [100, 500, 1200, 1500])])
@@ -357,6 +372,7 @@ class TestDataPathValidation:
             " with single client on single bucket")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8732')
     @pytest.mark.parametrize("obj_size, requests, num_clients",
                              [("8Mb", [10, 50, 100, 500], [10, 10, 12, 20])])
@@ -417,6 +433,7 @@ class TestDataPathValidation:
             " with multiple clients on single buckets")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8733')
     @pytest.mark.parametrize("obj_size, requests, num_clients",
                              [("8Mb", [100, 100, 100, 200], [1, 2, 3, 4])])
@@ -484,6 +501,7 @@ class TestDataPathValidation:
             " with multiple clients on multiple buckets")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_data_path
     @pytest.mark.tags('TEST-8734')
     @pytest.mark.parametrize("obj_size, requests, num_clients",
                              [("8Mb", [120, 150], [10, 2])])

--- a/tests/s3/test_delayed_delete.py
+++ b/tests/s3/test_delayed_delete.py
@@ -288,6 +288,7 @@ class TestDelayedDelete:
                              resp[1]["ContentLength"]]
         return obj_dict
 
+    @pytest.mark.s3_ops
     @pytest.mark.s3_delete
     @pytest.mark.tags('TEST-28995')
     @CTFailOn(error_handler)
@@ -326,6 +327,7 @@ class TestDelayedDelete:
                 logging.info("The Last modified time"
                              " is changed of %s", {objects})
 
+    @pytest.mark.s3_ops
     @pytest.mark.s3_delete
     @pytest.mark.tags('TEST-29032')
     @CTFailOn(error_handler)
@@ -409,6 +411,7 @@ class TestDelayedDelete:
                           "Old time is %s new time is %s",
                           {last_m_time_o}, {last_m_time_r})
 
+    @pytest.mark.s3_ops
     @pytest.mark.s3_delete
     @pytest.mark.tags('TEST-28444')
     @CTFailOn(error_handler)
@@ -486,6 +489,7 @@ class TestDelayedDelete:
             logging.info("The Last modified time"
                          " is different %s, %s", last_m_time_o, last_m_time_r)
 
+    @pytest.mark.s3_ops
     @pytest.mark.s3_delete
     @pytest.mark.tags('TEST-29043')
     @CTFailOn(error_handler)
@@ -533,6 +537,7 @@ class TestDelayedDelete:
                           " from bucket %s", self.test_file,
                           self.bucket_name)
 
+    @pytest.mark.s3_ops
     @pytest.mark.s3_delete
     @pytest.mark.tags('TEST-29159')
     @CTFailOn(error_handler)
@@ -576,6 +581,7 @@ class TestDelayedDelete:
         if obj_size_r == obj_size:
             self.log.info("Obj size are same %s", {obj_size_r})
 
+    @pytest.mark.s3_ops
     @pytest.mark.s3_delete
     @pytest.mark.tags("TEST-28990")
     @CTFailOn(error_handler)
@@ -607,6 +613,7 @@ class TestDelayedDelete:
         self.log.info("Completed: Verify background deletes using multiple "
                       "objects delete operation")
 
+    @pytest.mark.s3_ops
     @pytest.mark.s3_delete
     @pytest.mark.tags("TEST-28991")
     @CTFailOn(error_handler)
@@ -633,6 +640,7 @@ class TestDelayedDelete:
         self.log.info("Completed: Verify background deletes when ran s3bench workload "
                       "on multiple buckets")
 
+    @pytest.mark.s3_ops
     @pytest.mark.s3_delete
     @pytest.mark.tags("TEST-28992")
     @CTFailOn(error_handler)
@@ -682,6 +690,7 @@ class TestDelayedDelete:
 
         self.log.info("Completed: Verify if deletion is successful post simple object delete")
 
+    @pytest.mark.s3_ops
     @pytest.mark.s3_delete
     @pytest.mark.tags("TEST-28993")
     @CTFailOn(error_handler)

--- a/tests/s3/test_delete_account_temp_cred.py
+++ b/tests/s3/test_delete_account_temp_cred.py
@@ -156,6 +156,7 @@ class TestDeleteAccountTempCred:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_account_creds
     @pytest.mark.tags("TEST-6208")
     @CTFailOn(error_handler)
     def test_4518(self):
@@ -184,6 +185,7 @@ class TestDeleteAccountTempCred:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_account_creds
     @pytest.mark.tags("TEST-6207")
     @CTFailOn(error_handler)
     def test_4519(self):
@@ -211,6 +213,7 @@ class TestDeleteAccountTempCred:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_account_creds
     @pytest.mark.tags("TEST-6206")
     @CTFailOn(error_handler)
     def test_4520(self):
@@ -240,6 +243,7 @@ class TestDeleteAccountTempCred:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_account_creds
     @pytest.mark.tags("TEST-6205")
     @CTFailOn(error_handler)
     def test_4521(self):
@@ -279,6 +283,7 @@ class TestDeleteAccountTempCred:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_account_creds
     @pytest.mark.tags("TEST-6204")
     @CTFailOn(error_handler)
     def test_4522(self):
@@ -328,6 +333,7 @@ class TestDeleteAccountTempCred:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_account_creds
     @pytest.mark.tags("TEST-6203")
     @CTFailOn(error_handler)
     def test_4523(self):
@@ -379,6 +385,7 @@ class TestDeleteAccountTempCred:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_account_creds
     @pytest.mark.tags("TEST-6202")
     @CTFailOn(error_handler)
     def test_4525(self):
@@ -413,6 +420,7 @@ class TestDeleteAccountTempCred:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_account_creds
     @pytest.mark.tags("TEST-6201")
     @CTFailOn(error_handler)
     def test_4526(self):
@@ -442,6 +450,7 @@ class TestDeleteAccountTempCred:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_account_creds
     @pytest.mark.tags("TEST-6200")
     @CTFailOn(error_handler)
     def test_4692(self):

--- a/tests/s3/test_dos_scalability.py
+++ b/tests/s3/test_dos_scalability.py
@@ -110,6 +110,7 @@ class TestDosScalability:
         self.log.info("ENDED: Teardown Operations")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_scalability
     @pytest.mark.tags('TEST-8724')
     @pytest.mark.parametrize("num_clients, num_sample, obj_size", [(400, 1000, "1Mb")])
     # @CTFailOn(error_handler)
@@ -155,6 +156,7 @@ class TestDosScalability:
         self.log.info("ENDED: Test constant 400 S3 operations using s3bench.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_scalability
     @pytest.mark.tags('TEST-9657')
     @pytest.mark.parametrize("num_clients, num_sample, obj_size", [(300, 1000, "1Mb")])
     # @CTFailOn(error_handler)
@@ -200,6 +202,7 @@ class TestDosScalability:
         self.log.info("ENDED: Test constant 300 S3 operations using s3bench")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_scalability
     @pytest.mark.tags('TEST-9658')
     @pytest.mark.parametrize("num_clients, num_sample, obj_size", [(1000, 1000, "1Mb")])
     # @CTFailOn(error_handler)
@@ -245,6 +248,7 @@ class TestDosScalability:
         self.log.info("ENDED: Test constant 1000 S3 operations using s3bench")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_scalability
     @pytest.mark.tags('TEST-9659')
     @pytest.mark.parametrize("nclients, obj_size", [([1000, 1200, 1500], "1Mb")])
     # @CTFailOn(error_handler)
@@ -297,6 +301,7 @@ class TestDosScalability:
                       "1500")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_scalability
     @pytest.mark.tags('TEST-9660')
     @pytest.mark.parametrize("obj_size, nclients", [("1Mb", [1000, 1500, 1000, 1500])])
     # @CTFailOn(error_handler)
@@ -347,6 +352,7 @@ class TestDosScalability:
                       "back to 1000 then to 1500 again")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_scalability
     @pytest.mark.tags('TEST-8725')
     @pytest.mark.parametrize("num_clients, num_sample, obj_size", [(100, 1000000, "1Kb")])
     # # @CTFailOn(error_handler)

--- a/tests/s3/test_iam_account_login.py
+++ b/tests/s3/test_iam_account_login.py
@@ -101,6 +101,8 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5651")
     @CTFailOn(error_handler)
     def test_2805(self):
@@ -133,6 +135,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5650")
     @CTFailOn(error_handler)
     def test_2806(self):
@@ -165,6 +168,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5652")
     @CTFailOn(error_handler)
     def test_2807(self):
@@ -219,6 +223,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5645")
     @CTFailOn(error_handler)
     def test_2808(self):
@@ -258,6 +263,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5644")
     @CTFailOn(error_handler)
     def test_2809(self):
@@ -298,6 +304,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5643")
     @CTFailOn(error_handler)
     def test_2810(self):
@@ -320,6 +327,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5642")
     @CTFailOn(error_handler)
     def test_2811(self):
@@ -344,6 +352,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5649")
     @CTFailOn(error_handler)
     def test_2812(self):
@@ -363,6 +372,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5648")
     @CTFailOn(error_handler)
     def test_2813(self):
@@ -382,6 +392,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5641")
     @CTFailOn(error_handler)
     def test_2814(self):
@@ -423,6 +434,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5646")
     @CTFailOn(error_handler)
     def test_2815(self):
@@ -464,6 +476,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5647")
     @CTFailOn(error_handler)
     def test_2816(self):
@@ -525,6 +538,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5629")
     @CTFailOn(error_handler)
     def test_2829(self):
@@ -554,6 +568,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5628")
     @CTFailOn(error_handler)
     def test_2830(self):
@@ -575,6 +590,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5627")
     @CTFailOn(error_handler)
     def test_2831(self):
@@ -608,6 +624,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5626")
     @CTFailOn(error_handler)
     def test_2832(self):
@@ -646,6 +663,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5640")
     @CTFailOn(error_handler)
     def test_2833(self):
@@ -713,6 +731,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5611")
     @CTFailOn(error_handler)
     def test_2834(self):
@@ -769,6 +788,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5614")
     @CTFailOn(error_handler)
     def test_2835(self):
@@ -822,6 +842,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5616")
     @CTFailOn(error_handler)
     def test_2836(self):
@@ -878,6 +899,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5613")
     @CTFailOn(error_handler)
     def test_2837(self):
@@ -936,6 +958,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5612")
     @CTFailOn(error_handler)
     def test_2838(self):
@@ -987,6 +1010,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5610")
     @CTFailOn(error_handler)
     def test_2839(self):
@@ -1034,6 +1058,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5622")
     @CTFailOn(error_handler)
     def test_2840(self):
@@ -1072,6 +1097,7 @@ class TestAccountLoginProfile:
             " which didn't have the login profile created")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5621")
     @CTFailOn(error_handler)
     def test_2841(self):
@@ -1107,6 +1133,7 @@ class TestAccountLoginProfile:
             "which doesnt exist")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5617")
     @CTFailOn(error_handler)
     def test_2842(self):
@@ -1159,6 +1186,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5620")
     @CTFailOn(error_handler)
     def test_2843(self):
@@ -1211,6 +1239,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5618")
     @CTFailOn(error_handler)
     def test_2844(self):
@@ -1268,6 +1297,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5679")
     @CTFailOn(error_handler)
     def test_2845(self):
@@ -1338,6 +1368,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5630")
     @CTFailOn(error_handler)
     def test_2882(self):
@@ -1364,6 +1395,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5634")
     @CTFailOn(error_handler)
     def test_2883(self):
@@ -1387,6 +1419,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5625")
     @CTFailOn(error_handler)
     def test_2884(self):
@@ -1424,6 +1457,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5658")
     @CTFailOn(error_handler)
     def test_2885(self):
@@ -1467,6 +1501,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5608")
     @CTFailOn(error_handler)
     def test_2886(self):
@@ -1510,6 +1545,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5631")
     @CTFailOn(error_handler)
     def test_2887(self):
@@ -1541,6 +1577,7 @@ class TestAccountLoginProfile:
 
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5632")
     @CTFailOn(error_handler)
     def test_2888(self):
@@ -1570,6 +1607,7 @@ class TestAccountLoginProfile:
             "login profile for that acc.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5605")
     @CTFailOn(error_handler)
     def test_2889(self):
@@ -1626,6 +1664,7 @@ class TestAccountLoginProfile:
             " cred for the valid acc")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5606")
     @CTFailOn(error_handler)
     def test_2890(self):
@@ -1661,6 +1700,7 @@ class TestAccountLoginProfile:
             "for Get temp cred for the valid acc")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5623")
     @CTFailOn(error_handler)
     def test_2891(self):
@@ -1695,6 +1735,7 @@ class TestAccountLoginProfile:
             "the get temporary credentials")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5638")
     @CTFailOn(error_handler)
     def test_2892(self):
@@ -1746,6 +1787,7 @@ class TestAccountLoginProfile:
             " is present in that account")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5636")
     @CTFailOn(error_handler)
     def test_2893(self):
@@ -1781,6 +1823,7 @@ class TestAccountLoginProfile:
             "which is not present in that account")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5639")
     @CTFailOn(error_handler)
     def test_2894(self):
@@ -1835,6 +1878,7 @@ class TestAccountLoginProfile:
             "doesnt contain UserLoginProfile")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5637")
     @CTFailOn(error_handler)
     def test_2895(self):
@@ -1885,6 +1929,7 @@ class TestAccountLoginProfile:
             "duration which is present in that account")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_account
     @pytest.mark.tags("TEST-5635")
     @CTFailOn(error_handler)
     def test_2896(self):

--- a/tests/s3/test_iam_user_login.py
+++ b/tests/s3/test_iam_user_login.py
@@ -152,7 +152,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5664")
@@ -176,7 +176,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5665")
     @CTFailOn(error_handler)
     def test_2847(self):
@@ -194,7 +194,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5663")
     @CTFailOn(error_handler)
     def test_2848(self):
@@ -222,7 +222,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5681")
     @CTFailOn(error_handler)
     def test_2850(self):
@@ -244,7 +244,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5680")
     @CTFailOn(error_handler)
     def test_2851(self):
@@ -267,7 +267,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5704")
     @CTFailOn(error_handler)
     def test_2852(self):
@@ -291,7 +291,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5678")
     @CTFailOn(error_handler)
     def test_2853(self):
@@ -311,7 +311,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5662")
     @CTFailOn(error_handler)
     def test_2854(self):
@@ -336,7 +336,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5676")
     @CTFailOn(error_handler)
     def test_2855(self):
@@ -364,7 +364,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Not Supported cortxcli and BOTO3 Lib")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5677")
     @CTFailOn(error_handler)
     def test_2856(self):
@@ -390,7 +390,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5675")
     @CTFailOn(error_handler)
     def test_2857(self):
@@ -418,7 +418,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5703")
@@ -437,7 +437,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5702")
     @CTFailOn(error_handler)
     def test_2859(self):
@@ -455,7 +455,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5697")
     @CTFailOn(error_handler)
     def test_2860(self):
@@ -481,7 +481,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5695")
     @CTFailOn(error_handler)
     def test_2862(self):
@@ -500,7 +500,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5693")
     @CTFailOn(error_handler)
     def test_2863(self):
@@ -523,7 +523,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5699")
     @CTFailOn(error_handler)
     def test_2864(self):
@@ -542,7 +542,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5701")
     @CTFailOn(error_handler)
     def test_2865(self):
@@ -564,7 +564,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Newly added test scenario. Need to Add/Update JIRA ticket")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5673X")
     @CTFailOn(error_handler)
     def test_2909(self):
@@ -602,7 +602,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Newly added test scenario. Need to Add/Update JIRA ticket")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-XXXX")
     @CTFailOn(error_handler)
     def test_2910(self):
@@ -643,7 +643,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Newly added test scenario. Need to Add/Update JIRA ticket")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-XXXX")
     @CTFailOn(error_handler)
     def test_2911(self):
@@ -679,7 +679,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5688")
     @CTFailOn(error_handler)
     def test_2866(self):
@@ -698,7 +698,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5692")
     @CTFailOn(error_handler)
     def test_2867(self):
@@ -718,7 +718,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5691")
     @CTFailOn(error_handler)
     def test_2868(self):
@@ -738,7 +738,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5689")
     @CTFailOn(error_handler)
     def test_2869(self):
@@ -752,7 +752,7 @@ class TestUserLoginProfileTests:
         resp = self.iam_test_obj.create_user_login_profile(
             self.user_name,
             self.test_cfg["test_9832"]["password"]
-        )
+            )
         assert_true(resp[0], resp[1])
         self.log.info(
             "ENDED: Create login profile for IAM user without mentioning  "
@@ -763,7 +763,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Not supported by cortxcli and boto3 lib")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5690")
     @CTFailOn(error_handler)
     def test_2870(self):
@@ -787,7 +787,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5670")
     @CTFailOn(error_handler)
     def test_2871(self):
@@ -806,7 +806,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5671")
     @CTFailOn(error_handler)
     def test_2872(self):
@@ -822,7 +822,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5672")
     @CTFailOn(error_handler)
     def test_2873(self):
@@ -844,7 +844,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.lr
     @pytest.mark.tags("TEST-5668")
     @CTFailOn(error_handler)
@@ -878,7 +878,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.lr
     @pytest.mark.tags("TEST-5669")
     @CTFailOn(error_handler)
@@ -914,7 +914,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.lr
     @pytest.mark.tags("TEST-5682")
     @CTFailOn(error_handler)
@@ -951,7 +951,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.lr
     @pytest.mark.tags("TEST-5683")
     @CTFailOn(error_handler)
@@ -988,7 +988,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.lr
     @pytest.mark.tags("TEST-5661")
     @CTFailOn(error_handler)
@@ -1028,7 +1028,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.lr
     @pytest.mark.tags("TEST-5673")
     @CTFailOn(error_handler)
@@ -1070,7 +1070,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5705")
     @CTFailOn(error_handler)
     def test_2905(self):
@@ -1105,7 +1105,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5686")
     @CTFailOn(error_handler)
     def test_2929(self):
@@ -1156,7 +1156,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5660")
     @CTFailOn(error_handler)
     def test_2930(self):
@@ -1186,7 +1186,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5685")
     @CTFailOn(error_handler)
     def test_2931(self):
@@ -1228,7 +1228,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-10923")
     @CTFailOn(error_handler)
     def test_2932(self):
@@ -1266,7 +1266,7 @@ class TestUserLoginProfileTests:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5674")
     @CTFailOn(error_handler)
     def test_2933(self):
@@ -1299,7 +1299,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5659")
     @CTFailOn(error_handler)
     def test_2934(self):
@@ -1333,7 +1333,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5687")
     @CTFailOn(error_handler)
     def test_2935(self):
@@ -1362,7 +1362,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5666")
     @CTFailOn(error_handler)
     def test_2936(self):
@@ -1413,7 +1413,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5667")
     @CTFailOn(error_handler)
     def test_2937(self):
@@ -1450,7 +1450,7 @@ class TestUserLoginProfileTests:
     @pytest.mark.skip(reason="Will be taken after F-11D")
     @pytest.mark.parallel
     @pytest.mark.s3_ops
-    @pytest.mark.iam_user_login
+    @pytest.mark.s3_iam_user_auth
     @pytest.mark.tags("TEST-5684")
     @CTFailOn(error_handler)
     def test_2939(self):

--- a/tests/s3/test_iam_user_management.py
+++ b/tests/s3/test_iam_user_management.py
@@ -249,6 +249,7 @@ class TestIAMUserManagement:
                 assert_utils.assert_true(resp[0], resp[1])
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-23398")
     def test_23398_create_iam_user(self):
         """
@@ -279,6 +280,7 @@ class TestIAMUserManagement:
         self.log.info("%s %s", self.END_LOG_FORMAT, log.get_frame())
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-23399")
     def test_23399_list_user(self):
         """
@@ -326,6 +328,7 @@ class TestIAMUserManagement:
         self.log.info("%s %s", self.END_LOG_FORMAT, log.get_frame())
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-23400")
     def test_23400_create_access_key(self):
         """
@@ -366,6 +369,7 @@ class TestIAMUserManagement:
         self.log.info("%s %s", self.END_LOG_FORMAT, log.get_frame())
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-23401")
     def test_23401_delete_iam_user(self):
         """
@@ -401,6 +405,7 @@ class TestIAMUserManagement:
         self.log.info("%s %s", self.END_LOG_FORMAT, log.get_frame())
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-23402")
     def test_23402_check_access_key_count(self):
         """
@@ -456,6 +461,7 @@ class TestIAMUserManagement:
         self.log.info("%s %s", self.END_LOG_FORMAT, log.get_frame())
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-23463")
     def test_23463_crud_with_another_access_key(self):
         """
@@ -512,6 +518,7 @@ class TestIAMUserManagement:
         self.log.info("%s %s", self.END_LOG_FORMAT, log.get_frame())
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-22150")
     def test_22150(self):
         """use REST API call to create s3iamuser with special characters."""
@@ -537,6 +544,7 @@ class TestIAMUserManagement:
         self.log.info("ENDED: use REST API call to create s3iamuser with special characters.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-22148")
     def test_22148(self):
         """REST API to Update Login Profile without mentioning new Password for the s3iamuser."""
@@ -568,6 +576,7 @@ class TestIAMUserManagement:
             "ENDED: Update Login Profile without mentioning new Password for the s3iamuser.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-27277")
     def test_27277(self):
         """use REST API call to perform CRUD operations on s3iamuser."""
@@ -600,6 +609,7 @@ class TestIAMUserManagement:
         self.log.info("ENDED: use REST API call to perform CRUD operations on s3iamuser.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-27278")
     def test_27278(self):
         """use REST API call to perform accesskey CRUD operations for s3iamuser."""
@@ -648,6 +658,7 @@ class TestIAMUserManagement:
             "ENDED: use REST API call to perform accesskey CRUD operations for s3iamuser.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-21644")
     def test_21644(self):
         """use REST API call to create more than 2 Accesskeys for s3iamuser."""
@@ -686,6 +697,7 @@ class TestIAMUserManagement:
         self.log.info("ENDED: use REST API call to create more than 2 Accesskeys for s3iamuser.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-28776")
     def test_28776(self):
         """
@@ -757,6 +769,7 @@ class TestIAMUserManagement:
         self.log.info("####### Test Completed! #########")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_iam_user_mgnt
     @pytest.mark.tags("TEST-28852")
     def test_28852(self):
         """s3accounts creation with different maxIAMAccountLimit values"""

--- a/tests/s3/test_list_object_v2_using_aws_s3_api.py
+++ b/tests/s3/test_list_object_v2_using_aws_s3_api.py
@@ -103,6 +103,7 @@ class TestListObjectV2:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-15187")
     @CTFailOn(error_handler)
     def test_15187(self):
@@ -119,6 +120,7 @@ class TestListObjectV2:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-15188")
     @CTFailOn(error_handler)
     def test_15188(self):
@@ -134,6 +136,7 @@ class TestListObjectV2:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-15189")
     @CTFailOn(error_handler)
     def test_15189(self):
@@ -154,6 +157,7 @@ class TestListObjectV2:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-15190")
     @CTFailOn(error_handler)
     def test_15190(self):
@@ -172,6 +176,7 @@ class TestListObjectV2:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-15191")
     @CTFailOn(error_handler)
     def test_15191(self):
@@ -197,6 +202,7 @@ class TestListObjectV2:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-15194")
     @CTFailOn(error_handler)
     def test_15194(self):
@@ -216,6 +222,7 @@ class TestListObjectV2:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-15192")
     @CTFailOn(error_handler)
     def test_15192(self):

--- a/tests/s3/test_multipart_upload.py
+++ b/tests/s3/test_multipart_upload.py
@@ -167,6 +167,7 @@ class TestMultipartUpload:
         return mpu_id, parts
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5588')
     @CTFailOn(error_handler)
     def test_multipart_upload_for_file_2061_2065_2066_2069(self):
@@ -209,6 +210,7 @@ class TestMultipartUpload:
             "Initiate multipart upload, upload parts, list parts and complete multipart upload")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5583')
     @CTFailOn(error_handler)
     def test_abort_multipart_upload_2070(self):
@@ -236,6 +238,7 @@ class TestMultipartUpload:
         self.log.info("Abort Multipart upload")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5589')
     @CTFailOn(error_handler)
     def test_multipart_upload_file_1gb_to_10gb_2062(self):
@@ -275,6 +278,7 @@ class TestMultipartUpload:
             "Initiate Multipart upload for file of size of 1GB to 10GB having varying part size")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5590')
     @CTFailOn(error_handler)
     def test_multipart_upliad_large_file_with_metadata_2063(self):
@@ -303,6 +307,7 @@ class TestMultipartUpload:
             "Initiate Multipart upload for large file with meta data")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.release_regression
     @pytest.mark.tags('TEST-5599')
     @CTFailOn(error_handler)
@@ -332,6 +337,7 @@ class TestMultipartUpload:
             "Verify max no. of parts being listed by using List part command")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5591')
     @CTFailOn(error_handler)
     def test_list_multipart_upload_2068(self):
@@ -362,6 +368,7 @@ class TestMultipartUpload:
         self.log.info("List Multipart uploads")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5597')
     @CTFailOn(error_handler)
     def test_multipart_upload_through_configuration_file_2071(self):
@@ -420,6 +427,7 @@ class TestMultipartUpload:
             "Multipart upload through configuration file.(Automatic multipart upload)")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5584')
     @CTFailOn(error_handler)
     def test_abort_multipart_upload_from_client2_started_from_client1_2073(
@@ -450,6 +458,7 @@ class TestMultipartUpload:
             "Abort multipart upload from client 2 if upload has started from client 1")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5598')
     @CTFailOn(error_handler)
     def test_large_object_multipart_upload_2075(self):
@@ -485,6 +494,7 @@ class TestMultipartUpload:
             " seen from other client and if they can be accessed")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5586')
     @CTFailOn(error_handler)
     def test_multiprt_upload_having_more_than_10000_parts_2294(self):
@@ -528,6 +538,7 @@ class TestMultipartUpload:
         self.log.info("Create multipart upload having more than 10,000 parts")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5594')
     @CTFailOn(error_handler)
     def test_multipart_upload_all_parts_less_than_5mb_2296(self):
@@ -573,6 +584,7 @@ class TestMultipartUpload:
             "Multipart upload - create all parts less than 5 MB size, last part can be > 5 MB")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5596')
     @CTFailOn(error_handler)
     def test_multipart_upload_part_number_should_be_in_range_1_to_10k_2295(
@@ -607,6 +619,7 @@ class TestMultipartUpload:
                 f"Below listed part is outside of range 1 to {max_part_number}\n {part}")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5595')
     @CTFailOn(error_handler)
     def test_multipart_upload_few_part_more_than_5gb_2297(self):
@@ -651,6 +664,7 @@ class TestMultipartUpload:
             "Multipart upload - create few parts more than 5 GB size")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5587')
     @CTFailOn(error_handler)
     def test_create_upto_1k_multipart_uploads_2298(self):
@@ -714,6 +728,7 @@ class TestMultipartUpload:
         self.log.info("Create up to 1000 Multipart uploads")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5585')
     @CTFailOn(error_handler)
     def test_create_more_than_1k_multipart_uploads_2299(self):
@@ -775,6 +790,7 @@ class TestMultipartUpload:
         self.log.info("Create more than 1000 Multipart uploads")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5593')
     @CTFailOn(error_handler)
     def test_multipart_upload_varying_request_numbers_max_concurrent_requests_2300(
@@ -841,6 +857,7 @@ class TestMultipartUpload:
             "Multipart upload - by varying request numbers max_concurrent_requests")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-5592')
     @CTFailOn(error_handler)
     def test_multipart_upload_varying_multipart_threshold_2301(self):
@@ -904,6 +921,7 @@ class TestMultipartUpload:
         self.log.info("Multipart upload - by varying multipart_threshold")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_multipart_ops
     @pytest.mark.tags('TEST-8723')
     @CTFailOn(error_handler)
     def test_multipart_upload_with_invalid_json_input_631(self):

--- a/tests/s3/test_object_acl.py
+++ b/tests/s3/test_object_acl.py
@@ -195,6 +195,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5856")
     @CTFailOn(error_handler)
     def test_get_existing_obj_acl_2874(self):
@@ -216,6 +217,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5855")
     @CTFailOn(error_handler)
     def test_get_nonexising_obj_acl_2875(self):
@@ -240,6 +242,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5854")
     @CTFailOn(error_handler)
     def test_download_with_empty_key_2876(self):
@@ -262,6 +265,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5857")
     @CTFailOn(error_handler)
     def test_reupload_get_obj_acl_2877(self):
@@ -285,6 +289,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5858")
     @CTFailOn(error_handler)
     def test_verify_del_obj_acl_2878(self):
@@ -308,6 +313,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-19885")
     @CTFailOn(error_handler)
     def test_get_obj_acl_mp(self):
@@ -364,6 +370,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5862")
     @CTFailOn(error_handler)
     def test_multipart_upload_verify_obj_acl_2879(self):
@@ -425,6 +432,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5787")
     @CTFailOn(error_handler)
     def test_default_multipart_upload_2910(self):
@@ -465,6 +473,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5803")
     @CTFailOn(error_handler)
     def test_multipart_upload_chunksize_2911(self):
@@ -511,6 +520,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5804")
     @CTFailOn(error_handler)
     def test_upload_abort_multipart_upload_2912(self):
@@ -565,6 +575,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5760")
     @CTFailOn(error_handler)
     def test_vald_custom_acl_xml_3210(self):
@@ -596,6 +607,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5777")
     @CTFailOn(error_handler)
     def test_valid_canonical_id_3211(self):
@@ -625,6 +637,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5779")
     @CTFailOn(error_handler)
     def test_invalid_canonical_id_3212(self):
@@ -652,6 +665,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5759")
     @CTFailOn(error_handler)
     def test_valid_read_permission_3213(self):
@@ -685,6 +699,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5756")
     @CTFailOn(error_handler)
     def test_valid_write_permission_3214(self):
@@ -721,6 +736,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5757")
     @CTFailOn(error_handler)
     def test_valid_read_acp_permission_3215(self):
@@ -756,6 +772,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5742")
     @CTFailOn(error_handler)
     def test_valid_write_acp_permission_3216(self):
@@ -791,6 +808,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5763")
     @CTFailOn(error_handler)
     def test_invalid_permission_3217(self):
@@ -817,6 +835,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5762")
     @CTFailOn(error_handler)
     def test_invalid_xml_structure_3218(self):
@@ -844,6 +863,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5768")
     @CTFailOn(error_handler)
     def test_cross_account_grant_3226(self):
@@ -903,6 +923,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5765")
     @CTFailOn(error_handler)
     def test_put_objacl_invalid_obj_3227(self):
@@ -943,6 +964,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5780")
     @CTFailOn(error_handler)
     def test_put_obj_acl_100grants_3229(self):
@@ -974,6 +996,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5761")
     @CTFailOn(error_handler)
     def test_put_objacl_morethan_100grants_3230(self):
@@ -1016,6 +1039,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5767")
     @CTFailOn(error_handler)
     def test_put_obj_invalid_partid_display_3231(self):
@@ -1043,6 +1067,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5793")
     @CTFailOn(error_handler)
     def test_canned_acl_3682(self):
@@ -1101,6 +1126,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5791")
     @CTFailOn(error_handler)
     def test_put_get_canned_acl_3683(self):
@@ -1155,6 +1181,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5748")
     @CTFailOn(error_handler)
     def test_private_canned_write_acp_3684(self):
@@ -1214,6 +1241,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5794")
     @CTFailOn(error_handler)
     def test_canned_acl_authenticated_read_3685(self):
@@ -1275,6 +1303,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5797")
     @CTFailOn(error_handler)
     def test_put_get_canned_acl_authread_3686(self):
@@ -1345,6 +1374,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5749")
     @CTFailOn(error_handler)
     def test_authenticated_read_canned_acl_3687(self):
@@ -1428,6 +1458,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5792")
     @CTFailOn(error_handler)
     def test_canned_acl_private_read_acp_3688(self):
@@ -1511,6 +1542,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5795")
     @CTFailOn(error_handler)
     def test_authenticated_read_acp_permissions_3689(self):
@@ -1600,6 +1632,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5789")
     @CTFailOn(error_handler)
     def test_overwrite_private_canned_acl_3693(self):
@@ -1672,6 +1705,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5788")
     @CTFailOn(error_handler)
     def test_overwrite_authenticated_read_canned_acl_3692(self):
@@ -1745,6 +1779,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5745")
     @CTFailOn(error_handler)
     def test_bucket_owner_read_canned_acl_3694(self):
@@ -1845,6 +1880,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5746")
     @CTFailOn(error_handler)
     def test_bucket_owner_full_control_3695(self):
@@ -1948,6 +1984,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5820")
     @CTFailOn(error_handler)
     def test_read_acl_permission_3504(self):
@@ -1995,6 +2032,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5813")
     @CTFailOn(error_handler)
     def test_canned_read_acl_permission_3509(self):
@@ -2041,6 +2079,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5850")
     @CTFailOn(error_handler)
     def test_canned_private_read_acl_3543(self):
@@ -2089,6 +2128,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5851")
     @CTFailOn(error_handler)
     def test_private_full_control_3544(self):
@@ -2137,6 +2177,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5847")
     @CTFailOn(error_handler)
     def test_public_read_acp_permission_3546(self):
@@ -2185,6 +2226,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5845")
     @CTFailOn(error_handler)
     def test_public_read_write_acp_3547(self):
@@ -2233,6 +2275,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5843")
     @CTFailOn(error_handler)
     def test_public_read_write_acp_acl_3548(self):
@@ -2279,6 +2322,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5844")
     @CTFailOn(error_handler)
     def test_public_read_write_full_control_3549(self):
@@ -2325,6 +2369,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5853")
     @CTFailOn(error_handler)
     def test_authenticate_read_acl_3550(self):
@@ -2372,6 +2417,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5852")
     @CTFailOn(error_handler)
     def test_authenticate_read_acp_acl_3551(self):
@@ -2421,6 +2467,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5800")
     @CTFailOn(error_handler)
     def test_bucket_owner_read_canned_acl_3496(self):
@@ -2455,6 +2502,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5802")
     @CTFailOn(error_handler)
     def test_bucket_owner_full_control_acl_3497(self):
@@ -2490,6 +2538,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5799")
     @CTFailOn(error_handler)
     def test_bucket_owner_read_canned_3498(self):
@@ -2576,6 +2625,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5801")
     @CTFailOn(error_handler)
     def test_bucket_owner_full_control_3499(self):
@@ -2663,6 +2713,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5805")
     @CTFailOn(error_handler)
     def test_bucket_owner_read_acl_full_control_3502(self):
@@ -2729,6 +2780,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5806")
     @CTFailOn(error_handler)
     def test_bucket_owner_full_control_read_canned_3503(self):
@@ -2790,6 +2842,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5817")
     @CTFailOn(error_handler)
     def test_full_control_write_acl_3505(self):
@@ -2840,6 +2893,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5818")
     @CTFailOn(error_handler)
     def test_full_control_read_acp_acl_3506(self):
@@ -2889,6 +2943,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5816")
     @CTFailOn(error_handler)
     def test_bucket_owner_full_control_write_acp_3507(self):
@@ -2936,6 +2991,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5822")
     @CTFailOn(error_handler)
     def test_bucket_owner_full_control_acl_3508(self):
@@ -2984,6 +3040,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5809")
     @CTFailOn(error_handler)
     def test_bucket_owner_read_write_acl_permission_3510(self):
@@ -3034,6 +3091,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5811")
     @CTFailOn(error_handler)
     def test_bucket_owner_read_acp_acl_3511(self):
@@ -3083,6 +3141,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5808")
     @CTFailOn(error_handler)
     def test_bucket_owner_read_write_acp_acl_3512(self):
@@ -3132,6 +3191,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5815")
     @CTFailOn(error_handler)
     def test_bucket_owner_read_full_control_acl_3513(self):
@@ -3182,6 +3242,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5861")
     @CTFailOn(error_handler)
     def test_private_acl_full_control_3552(self):
@@ -3242,6 +3303,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5848")
     @CTFailOn(error_handler)
     def test_private_request_body_full_contorl_header_3553(self):
@@ -3299,6 +3361,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5848")
     @CTFailOn(error_handler)
     def test_private_full_contorl_acl_permission_3554(self):
@@ -3358,6 +3421,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-19886")
     @CTFailOn(error_handler)
     def test_put_object_private_canned_acl_159(self):
@@ -3419,6 +3483,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-19887")
     @CTFailOn(error_handler)
     def test_put_object_private_canned_acl_170(self):
@@ -3480,6 +3545,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-19888")
     @CTFailOn(error_handler)
     def test_put_object_owner_read_acl_172(self):
@@ -3570,6 +3636,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-19889")
     @CTFailOn(error_handler)
     def test_full_contorl_canned_acl_permission_175(self):
@@ -3666,6 +3733,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-7566")
     @CTFailOn(error_handler)
     def test_public_read_get_obj_tagging_453(self):
@@ -3754,6 +3822,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-7567")
     @CTFailOn(error_handler)
     def test_full_contorl_get_object_tagging_423(self):
@@ -3843,6 +3912,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-7568")
     @CTFailOn(error_handler)
     def test_write_execute_get_object_tagging_421(self):
@@ -3931,6 +4001,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-7569")
     @CTFailOn(error_handler)
     def test_read_permission_get_object_tagging_419(self):
@@ -4018,6 +4089,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-7570")
     @CTFailOn(error_handler)
     def test_get_object_tagging_410(self):
@@ -4058,6 +4130,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-17181")
     def test_put_object_acl_public_read_write_169(self):
         """Put-object-acl from cross account on obj with public-read-write canned-acl permission."""
@@ -4118,6 +4191,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-7573")
     @CTFailOn(error_handler)
     def test_public_read_canned_acl_167(self):
@@ -4179,6 +4253,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-7574")
     @CTFailOn(error_handler)
     def test_put_get_obj_acl_311(self):
@@ -4239,6 +4314,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-7575")
     @CTFailOn(error_handler)
     def test_put_obj_read_acp_get_obj_acl_286(self):
@@ -4276,6 +4352,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-7576")
     @CTFailOn(error_handler)
     def test_put_get_obj_acl_285(self):
@@ -4297,6 +4374,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5743")
     @CTFailOn(error_handler)
     def test_put_get_obj_acl_xml_3453(self):
@@ -4369,6 +4447,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5786")
     @CTFailOn(error_handler)
     def test_put_check_invalid_canonical_id_3454(self):
@@ -4421,6 +4500,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5785")
     @CTFailOn(error_handler)
     def test_put_get_obj_control_permission_3455(self):
@@ -4500,6 +4580,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5784")
     @CTFailOn(error_handler)
     def test_read_acp_permission_acl_xml_3456(self):
@@ -4576,6 +4657,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5782")
     @CTFailOn(error_handler)
     def test_write_acp_permission_get_acl_xml_3457(self):
@@ -4652,6 +4734,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5755")
     @CTFailOn(error_handler)
     def test_write_permission_get_obj_acl_xml_3458(self):
@@ -4728,6 +4811,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-7560")
     @CTFailOn(error_handler)
     def test_full_control_permision_header_3459(self):
@@ -4808,6 +4892,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5754")
     @CTFailOn(error_handler)
     def test_put_obj_read_permission_permission_header_3460(self):
@@ -4894,6 +4979,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5753")
     @CTFailOn(error_handler)
     def test_put_obj_read_acp_permission_header_3461(self):
@@ -4981,6 +5067,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5750")
     @CTFailOn(error_handler)
     def test_write_permission_header_3462(self):
@@ -5067,6 +5154,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5752")
     @CTFailOn(error_handler)
     def test_write_permission_header_3463(self):
@@ -5119,6 +5207,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-7565")
     @CTFailOn(error_handler)
     def test_full_contorl_read_acl_permisisno_3541(self):
@@ -5158,6 +5247,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5766")
     @CTFailOn(error_handler)
     def test_invalid_custom_acl_xml_json_3228(self):
@@ -5188,6 +5278,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5769")
     @CTFailOn(error_handler)
     def test_put_get_object_with_same_account_3248(self):
@@ -5230,6 +5321,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5747")
     @CTFailOn(error_handler)
     def test_put_get_object_3249(self):
@@ -5246,6 +5338,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5790")
     @CTFailOn(error_handler)
     def test_get_object_by_changed_account_3250(self):
@@ -5272,6 +5365,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5775")
     @CTFailOn(error_handler)
     def test_put_obj_write_access_get_obj_3254(self):
@@ -5299,6 +5393,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5772")
     @CTFailOn(error_handler)
     def test_put_obj_read_access_get_obj_3255(self):
@@ -5320,6 +5415,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5774")
     def test_put_obj_acl_read_acp_3256(self):
         """Put obj ACL with Account1, grant read-acp access to Account2 & Get obj with Account2."""
@@ -5345,6 +5441,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5771")
     @CTFailOn(error_handler)
     def test_put_obj_write_acp_get_obj_3257(self):
@@ -5371,6 +5468,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5744")
     @CTFailOn(error_handler)
     def test_put_get_object_acl_xml_3451(self):
@@ -5411,6 +5509,7 @@ class TestObjectACL:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_acl
     @pytest.mark.tags("TEST-5741")
     @CTFailOn(error_handler)
     def test_put_obj_full_control_get_acl_xml_3452(self):

--- a/tests/s3/test_object_metadata_operations.py
+++ b/tests/s3/test_object_metadata_operations.py
@@ -120,6 +120,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5482")
     @CTFailOn(error_handler)
     def test_object_key_alphanumeric_chars_1983(self):
@@ -134,6 +135,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5478")
@@ -150,6 +152,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5480")
@@ -168,6 +171,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5479")
     @CTFailOn(error_handler)
     def test_key_existing_object_key_1986(self):
@@ -207,6 +211,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5487")
     @CTFailOn(error_handler)
     def test_key_1024byte_long_1987(self):
@@ -228,6 +233,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5483")
     @CTFailOn(error_handler)
     def test_key_with_numeric_1989(self):
@@ -244,6 +250,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5486")
     @CTFailOn(error_handler)
     def test_keysize_morethan_1024bytes_1990(self):
@@ -283,6 +290,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-7636")
     @CTFailOn(error_handler)
     def test_keyname_delimiters_prefixes_1991(self):
@@ -304,6 +312,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5484")
     @CTFailOn(error_handler)
     def test_key_chars_require_special_handling_1992(self):
@@ -351,6 +360,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5485")
     @CTFailOn(error_handler)
     def test_keyname_chars_avoidlist_1993(self):
@@ -398,6 +408,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5488")
     @CTFailOn(error_handler)
     def test_metadata_with_adding_new_object_1994(self):
@@ -416,6 +427,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5489")
     @CTFailOn(error_handler)
     def test_update_metadat_while_copying_1995(self):
@@ -469,6 +481,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5476")
     @CTFailOn(error_handler)
     def test_update_metadata_upto2kb_1997(self):
@@ -499,6 +512,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5477")
     @CTFailOn(error_handler)
     def test_metadata_morethan2kb_1998(self):
@@ -547,6 +561,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5474")
     @CTFailOn(error_handler)
     def test_max_objects_2287(self):
@@ -592,6 +607,7 @@ class TestObjectMetadataOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5475")
     @CTFailOn(error_handler)
     def test_max_object_size_2292(self):

--- a/tests/s3/test_object_tagging.py
+++ b/tests/s3/test_object_tagging.py
@@ -104,6 +104,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5549")
     @CTFailOn(error_handler)
     def test_verify_putobj_tagging_2457(self):
@@ -131,6 +132,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5557")
     @CTFailOn(error_handler)
     def test_getobj_tagging_2458(self):
@@ -158,6 +160,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5561")
     @CTFailOn(error_handler)
     def test_delobj_tagging_2459(self):
@@ -197,6 +200,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5547")
     @CTFailOn(error_handler)
     def test_putobj_taggingsupport_2460(self):
@@ -231,6 +235,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5555")
     @CTFailOn(error_handler)
     def test_getobj_taggingsupport_2461(self):
@@ -272,6 +277,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5553")
     @CTFailOn(error_handler)
     def test_multipartupload_taggingsupport_2462(self):
@@ -339,6 +345,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5574")
     @CTFailOn(error_handler)
     def test_add_maximum_tags_existing_object_2463(self):
@@ -370,6 +377,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5576")
     @CTFailOn(error_handler)
     def test_add10tags_existingobject_2464(self):
@@ -411,6 +419,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5564")
     @CTFailOn(error_handler)
     def test_unique_tagkeys_2465(self):
@@ -452,6 +461,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5578")
     @CTFailOn(error_handler)
     def test_add_duplicate_tags_2466(self):
@@ -500,6 +510,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5579")
     @CTFailOn(error_handler)
     def test_key_128unicodechars_2467(self):
@@ -529,6 +540,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5570")
     @CTFailOn(error_handler)
     def test_key_with_more_than_128_unichargs_2468(self):
@@ -571,6 +583,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5572")
     @CTFailOn(error_handler)
     def test_tagvalue256chars_2469(self):
@@ -600,6 +613,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5571")
     @CTFailOn(error_handler)
     def test_tag_value_512_unichars_2470(self):
@@ -642,6 +656,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5552")
     @CTFailOn(error_handler)
     def test_tagkeys_labels_2471(self):
@@ -683,6 +698,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5551")
     @CTFailOn(error_handler)
     def test_case_sensitive_labels_2472(self):
@@ -725,6 +741,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5566")
     @CTFailOn(error_handler)
     def test_valid_specialchars_2473(self):
@@ -752,6 +769,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5569")
     @CTFailOn(error_handler)
     def test_invalid_specialchars_2474(self):
@@ -802,6 +820,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5568")
     @CTFailOn(error_handler)
     def test_invalid_specialchars_2475(self):
@@ -852,6 +871,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5567")
     @CTFailOn(error_handler)
     def test_special_chars_2476(self):
@@ -901,6 +921,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5565")
     @CTFailOn(error_handler)
     def test_duplicate_name_object_tag_support_2477(self):
@@ -957,6 +978,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5562")
     @CTFailOn(error_handler)
     def test_max_object_max_tags_2478(self):
@@ -1014,6 +1036,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5573")
     @CTFailOn(error_handler)
     def test_metadata_object_tags_2479(self):
@@ -1056,6 +1079,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5575")
     @CTFailOn(error_handler)
     def test_user_defined_metadata_2480(self):
@@ -1129,6 +1153,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5563")
     @CTFailOn(error_handler)
     def test_user_defined_metadata_2481(self):
@@ -1174,6 +1199,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5577")
     @CTFailOn(error_handler)
     def test_maximum_object_tags_2482(self):
@@ -1219,6 +1245,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5548")
     @CTFailOn(error_handler)
     def test_put_object_tagging_2483(self):
@@ -1247,6 +1274,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5556")
     @CTFailOn(error_handler)
     def test_get_object_tagging_2484(self):
@@ -1273,6 +1301,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5559")
     @CTFailOn(error_handler)
     def test_delobj_tagging_2485(self):
@@ -1299,6 +1328,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5546")
     @CTFailOn(error_handler)
     def test_put_non_existing_object_tagging_2486(self):
@@ -1329,6 +1359,7 @@ class TestObjectTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5554")
     @CTFailOn(error_handler)
     def test_get_non_existing_object_tagging_2487(self):

--- a/tests/s3/test_object_workflow_operations.py
+++ b/tests/s3/test_object_workflow_operations.py
@@ -107,6 +107,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5498")
@@ -134,6 +135,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5499")
     @CTFailOn(error_handler)
     def test_copy_different_sizes_2209(self):
@@ -166,6 +168,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5496")
     @CTFailOn(error_handler)
     def test_recursive_copy_2210(self):
@@ -188,6 +191,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5502")
     def test_add_object_non_existing_bucket2211(self):
         """Add Object to non existing bucket."""
@@ -205,6 +209,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5500")
     @CTFailOn(error_handler)
     def test_copy_object_local_file_2213(self):
@@ -257,6 +262,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5495")
@@ -298,6 +304,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5501")
     @CTFailOn(error_handler)
     def test_download_byte_range_2215(self):
@@ -338,6 +345,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5493")
@@ -384,6 +392,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5503")
     @CTFailOn(error_handler)
     def test_add_metadata_verify_object_2218(self):
@@ -451,6 +460,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5494")
     @CTFailOn(error_handler)
     def test_remove_metadata_2219(self):
@@ -506,6 +516,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.release_regression
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-5497")
@@ -562,6 +573,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-5492")
     @CTFailOn(error_handler)
     def test_delete_non_existing_object_2221(self):
@@ -589,6 +601,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-8713")
     @CTFailOn(error_handler)
     def test_del_object_verbose_mode_7653(self):
@@ -620,6 +633,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-8714")
     @CTFailOn(error_handler)
     def test_delete_object_quiet_mode_7655(self):
@@ -656,6 +670,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-8715")
     @CTFailOn(error_handler)
     def test_delete_objects_and_mention_1001_objects_7656(self):
@@ -684,6 +699,7 @@ class TestObjectWorkflowOperations:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-8716")
     @CTFailOn(error_handler)
     def test_delete_objects_and_mention_1000_objects_7657(self):

--- a/tests/s3/test_openldap.py
+++ b/tests/s3/test_openldap.py
@@ -366,6 +366,7 @@ class TestOpenLdap:
         self.log.info("ENDED: Teardown operations")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_openldap
     @pytest.mark.tags('TEST-7948')
     @CTFailOn(error_handler)
     def test_5066(self):
@@ -410,6 +411,7 @@ class TestOpenLdap:
             "configuration directory is done successfully")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_openldap
     @pytest.mark.tags('TEST-7949')
     @CTFailOn(error_handler)
     def test_5067(self):
@@ -453,6 +455,7 @@ class TestOpenLdap:
             "ENDED: Test to verify & check backup of openldap Data Directory is done successfully")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_openldap
     @pytest.mark.tags('TEST-7950')
     @CTFailOn(error_handler)
     def test_5068(self):
@@ -549,6 +552,7 @@ class TestOpenLdap:
             "configuration directory is done successfully")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_openldap
     @pytest.mark.tags('TEST-7951')
     @CTFailOn(error_handler)
     def test_5069(self):
@@ -659,6 +663,7 @@ class TestOpenLdap:
             "to what it was previously before restore.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_openldap
     @pytest.mark.tags('TEST-7952')
     @CTFailOn(error_handler)
     def test_5070(self):
@@ -754,6 +759,7 @@ class TestOpenLdap:
             "openldap data directories is done successfully")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_openldap
     @pytest.mark.tags('TEST-7953')
     @CTFailOn(error_handler)
     def test_5071(self):
@@ -859,6 +865,7 @@ class TestOpenLdap:
             "permissions of the data directory to what it was previously")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_openldap
     @pytest.mark.tags('TEST-8020')
     @CTFailOn(error_handler)
     def test_5073(self):
@@ -897,6 +904,7 @@ class TestOpenLdap:
             "enc_ldap_passwd_in_cfg.sh script.")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_openldap
     @pytest.mark.tags('TEST-8021')
     @CTFailOn(error_handler)
     def test_5074(self):
@@ -949,6 +957,7 @@ class TestOpenLdap:
             "file is updated post password change/reset")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_openldap
     @pytest.mark.tags('TEST-8022')
     @CTFailOn(error_handler)
     def test_5075(self):
@@ -1003,6 +1012,7 @@ class TestOpenLdap:
             " with uppercase/lowercase characters")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_openldap
     @pytest.mark.tags('TEST-8023')
     @CTFailOn(error_handler)
     def test_5076(self):

--- a/tests/s3/test_put_bucket.py
+++ b/tests/s3/test_put_bucket.py
@@ -99,6 +99,7 @@ class TestPutBucket:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_put
     @pytest.mark.tags('TEST-5838')
     @CTFailOn(error_handler)
     def test_verify_put_bucket_authorization_header_missing_412(self):
@@ -112,6 +113,7 @@ class TestPutBucket:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_put
     @pytest.mark.tags('TEST-5839')
     @CTFailOn(error_handler)
     def test_verify_put_bucket_ip_address_format_authorization_header_missing_415(
@@ -127,6 +129,7 @@ class TestPutBucket:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_put
     @pytest.mark.tags('TEST-5840')
     @CTFailOn(error_handler)
     def test_create_multiple_buckets_authorization_header_missing_416(self):
@@ -140,6 +143,7 @@ class TestPutBucket:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_bucket_put
     @pytest.mark.tags('TEST-5841')
     @CTFailOn(error_handler)
     def test_verify_put_bucket_without_giving_cacert_417(self):

--- a/tests/s3/test_s3_account_mgmt_delete_user_generate_access_key.py
+++ b/tests/s3/test_s3_account_mgmt_delete_user_generate_access_key.py
@@ -278,6 +278,7 @@ class TestAccountUserMgmtDeleteAccountCreateAccessKey:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_key
     @pytest.mark.tags("TEST-23321")
     @CTFailOn(error_handler)
     def test_23321(self):
@@ -348,6 +349,7 @@ class TestAccountUserMgmtDeleteAccountCreateAccessKey:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_key
     @pytest.mark.tags("TEST-23322")
     @CTFailOn(error_handler)
     def test_23322(self):
@@ -426,6 +428,7 @@ class TestAccountUserMgmtDeleteAccountCreateAccessKey:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_key
     @pytest.mark.tags("TEST-23323")
     @CTFailOn(error_handler)
     def test_23323(self):
@@ -501,6 +504,7 @@ class TestAccountUserMgmtDeleteAccountCreateAccessKey:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_key
     @pytest.mark.tags("TEST-23324")
     @CTFailOn(error_handler)
     def test_23324(self):
@@ -577,6 +581,7 @@ class TestAccountUserMgmtDeleteAccountCreateAccessKey:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_key
     @pytest.mark.tags("TEST-23379")
     @CTFailOn(error_handler)
     def test_23379(self):
@@ -646,6 +651,7 @@ class TestAccountUserMgmtDeleteAccountCreateAccessKey:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_key
     @pytest.mark.tags("TEST-23380")
     @CTFailOn(error_handler)
     def test_23380(self):
@@ -712,6 +718,7 @@ class TestAccountUserMgmtDeleteAccountCreateAccessKey:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_key
     @pytest.mark.tags("TEST-23381")
     @CTFailOn(error_handler)
     def test_23381(self):
@@ -763,6 +770,7 @@ class TestAccountUserMgmtDeleteAccountCreateAccessKey:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_key
     @pytest.mark.tags("TEST-23382")
     @CTFailOn(error_handler)
     def test_23382(self):
@@ -824,6 +832,7 @@ class TestAccountUserMgmtDeleteAccountCreateAccessKey:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_key
     @pytest.mark.tags("TEST-23395")
     @CTFailOn(error_handler)
     def test_23395(self):
@@ -885,6 +894,7 @@ class TestAccountUserMgmtDeleteAccountCreateAccessKey:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_key
     @pytest.mark.tags("TEST-23396")
     @CTFailOn(error_handler)
     def test_23396(self):

--- a/tests/s3/test_s3_account_user_management_reset_password.py
+++ b/tests/s3/test_s3_account_user_management_reset_password.py
@@ -188,6 +188,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-22793")
     @CTFailOn(error_handler)
     def test_22793(self):
@@ -257,6 +258,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-22794")
     @CTFailOn(error_handler)
     def test_22794(self):
@@ -315,6 +317,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-22795")
     @CTFailOn(error_handler)
     def test_22795(self):
@@ -374,6 +377,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-22796")
     @CTFailOn(error_handler)
     def test_22796(self):
@@ -426,6 +430,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-22797")
     @CTFailOn(error_handler)
     def test_22797(self):
@@ -483,6 +488,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-22798")
     @CTFailOn(error_handler)
     def test_22798(self):
@@ -564,6 +570,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-22799")
     @CTFailOn(error_handler)
     def test_22799(self):
@@ -630,6 +637,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-22800")
     @CTFailOn(error_handler)
     def test_22800(self):
@@ -697,6 +705,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-22801")
     @CTFailOn(error_handler)
     def test_22801(self):
@@ -753,6 +762,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-22802")
     @CTFailOn(error_handler)
     def test_22802(self):
@@ -813,6 +823,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-22882")
     @CTFailOn(error_handler)
     def test_22882(self):
@@ -884,6 +895,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-21502")
     @CTFailOn(error_handler)
@@ -916,6 +928,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.sanity
     @pytest.mark.tags("TEST-21514")
     @CTFailOn(error_handler)
@@ -948,6 +961,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-21517")
     @CTFailOn(error_handler)
     def test_21517(self):
@@ -997,6 +1011,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-21520")
     @CTFailOn(error_handler)
     def test_21520(self):
@@ -1026,6 +1041,7 @@ class TestAccountUserManagementResetPassword:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_acc_mgnt_pwd
     @pytest.mark.tags("TEST-21521")
     @CTFailOn(error_handler)
     def test_21521(self):

--- a/tests/s3/test_s3_concurrency.py
+++ b/tests/s3/test_s3_concurrency.py
@@ -317,6 +317,7 @@ class TestS3Concurrency:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_concurrency
     @pytest.mark.tags("TEST-7954")
     @CTFailOn(error_handler)
     def test_existing_objects_being_overwritten_by_multiple_client_2128(self):
@@ -351,6 +352,7 @@ class TestS3Concurrency:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_concurrency
     @pytest.mark.tags("TEST-7962")
     @CTFailOn(error_handler)
     def test_obj_download_triggered_from_client_and_delete_triggered_from_other_client_2129(
@@ -387,6 +389,7 @@ class TestS3Concurrency:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_concurrency
     @pytest.mark.tags("TEST-7956")
     @CTFailOn(error_handler)
     def test_object_download_in_progress_on_one_client_delete_bucket_triggered_from_other_2130(
@@ -425,6 +428,7 @@ class TestS3Concurrency:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_concurrency
     @pytest.mark.tags("TEST-7957")
     @CTFailOn(error_handler)
     def test_parallel_bucket_creation_of_same_name_from_two_different_clients_2131(
@@ -452,6 +456,7 @@ class TestS3Concurrency:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_concurrency
     @pytest.mark.tags("TEST-7958")
     @CTFailOn(error_handler)
     def test_parallel_deletion_of_same_object_from_two_different_clients_2132(
@@ -482,6 +487,7 @@ class TestS3Concurrency:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_concurrency
     @pytest.mark.tags("TEST-7959")
     @CTFailOn(error_handler)
     def test_upload_object_to_bucket_from_one_client_and_parallel_delete_bkt_from_other_client_2133(
@@ -522,6 +528,7 @@ class TestS3Concurrency:
             "try to delete the same bucket from other s3 client")
 
     @pytest.mark.s3_ops
+    @pytest.mark.s3_concurrency
     @pytest.mark.tags("TEST-7960")
     @CTFailOn(error_handler)
     def test_parallel_deletion_of_bucket_from_two_different_clients_2134(self):
@@ -551,6 +558,7 @@ class TestS3Concurrency:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_concurrency
     @pytest.mark.tags("TEST-7961")
     @CTFailOn(error_handler)
     def test_put_object_through_one_s3_client_try_deleting_it_from_other_client_2135(
@@ -584,6 +592,7 @@ class TestS3Concurrency:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_concurrency
     @pytest.mark.tags("TEST-7963")
     @CTFailOn(error_handler)
     def test_download_an_already_existing_obj_from_one_client_parallel_overwrite_it_2136(

--- a/tests/s3/test_s3_faulttolerance.py
+++ b/tests/s3/test_s3_faulttolerance.py
@@ -78,6 +78,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-18838")
     @pytest.mark.parametrize("object_size", ["50k"])
     def test_18838(self, object_size):
@@ -128,6 +129,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-18839")
     @pytest.mark.parametrize("object_size", ["33k"])
     def test_18839(self, object_size):
@@ -143,6 +145,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-18840")
     @pytest.mark.parametrize("object_size", ["4MB"])
     def test_18840(self, object_size):
@@ -155,6 +158,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-18841")
     @pytest.mark.parametrize("object_size", ["6MB"])
     def test_18841(self, object_size):
@@ -167,6 +171,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-18842")
     @CTFailOn(error_handler)
     def test_18842(self):
@@ -211,6 +216,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-18843")
     @CTFailOn(error_handler)
     def test_18843(self):
@@ -258,6 +264,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-19497")
     @pytest.mark.parametrize("object_size", ["50k"])
     def test_19497(self, object_size):
@@ -318,6 +325,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-19499")
     @pytest.mark.parametrize("object_size", ["33k"])
     def test_19499(self, object_size):
@@ -327,6 +335,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-19501")
     @pytest.mark.parametrize("object_size", ["4MB"])
     def test_19501(self, object_size):
@@ -336,6 +345,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-19504")
     @pytest.mark.parametrize("object_size", ["8MB"])
     def test_19504(self, object_size):
@@ -345,6 +355,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-19505")
     @pytest.mark.parametrize("object_size", ["4MB"])
     def test_19505(self, object_size):
@@ -388,6 +399,7 @@ class TestS3FaultTolerance:
 
     @pytest.mark.skip(reason="F-24A feature under development.")
     @pytest.mark.s3_ops
+    @pytest.mark.s3_faulttolerance
     @pytest.mark.tags("TEST-19506")
     @pytest.mark.parametrize("object_size", ["33k"])
     def test_19506(self, object_size):

--- a/tests/s3/test_support_bundle.py
+++ b/tests/s3/test_support_bundle.py
@@ -302,6 +302,7 @@ class TestSupportBundle:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8024 ")
     @CTFailOn(error_handler)
     def test_dest_has_less_space_5274(self):
@@ -333,6 +334,7 @@ class TestSupportBundle:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8025")
     @CTFailOn(error_handler)
     def test_collect_triggered_simultaneously_5280(self):
@@ -372,6 +374,7 @@ class TestSupportBundle:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8026")
     @CTFailOn(error_handler)
     def test_core_m0traces_all_instances_5282(self):
@@ -428,6 +431,7 @@ class TestSupportBundle:
     # causing cluster failure so disabling this test-case
     @pytest.mark.skip
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8691 ")
     def test_collection_with_network_fluctuation_5272(self):
         """Support bundle collection with network fluctuation."""
@@ -470,6 +474,7 @@ class TestSupportBundle:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8692 ")
     @CTFailOn(error_handler)
     def test_collecion_primary_secondary_nodes_5273(self):
@@ -515,6 +520,7 @@ class TestSupportBundle:
     # causing cluster failure so disabling this test-case
     @pytest.mark.skip
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8694")
     @CTFailOn(error_handler)
     def test_collet_authservice_down_5276(self):
@@ -558,6 +564,7 @@ class TestSupportBundle:
     # causing cluster failure so disabling this test-case
     @pytest.mark.skip
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8695")
     @CTFailOn(error_handler)
     def test_collection_haproxy_down_5277(self):
@@ -601,6 +608,7 @@ class TestSupportBundle:
     # causing cluster failure so disabling this test-case
     @pytest.mark.skip
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8696")
     @CTFailOn(error_handler)
     def test_collection_cluster_down_5278(self):
@@ -635,6 +643,7 @@ class TestSupportBundle:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8697")
     @CTFailOn(error_handler)
     def test_collection_one_after_other_5279(self):
@@ -672,6 +681,7 @@ class TestSupportBundle:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8698 ")
     @CTFailOn(error_handler)
     def test_s3server_logs_all_instances_5281(self):
@@ -713,6 +723,7 @@ class TestSupportBundle:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8699")
     @CTFailOn(error_handler)
     def test_authserver_logs_5283(self):
@@ -750,6 +761,7 @@ class TestSupportBundle:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8700")
     @CTFailOn(error_handler)
     def test_haproxy_logs_5284(self):
@@ -789,6 +801,7 @@ class TestSupportBundle:
     # causing cluster failure so disabling this test-case
     @pytest.mark.skip
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8693")
     @CTFailOn(error_handler)
     def test_collection_s3server_down_5275(self):
@@ -831,6 +844,7 @@ class TestSupportBundle:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8701")
     @CTFailOn(error_handler)
     def test_collection_script_5270(self):
@@ -863,6 +877,7 @@ class TestSupportBundle:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8689")
     @CTFailOn(error_handler)
     def test_system_configs_5285(self):
@@ -919,6 +934,7 @@ class TestSupportBundle:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.s3_support_bundle
     @pytest.mark.tags("TEST-8690")
     @CTFailOn(error_handler)
     def test_collect_system_info_stats_5286(self):


### PR DESCRIPTION
# Problem Statement
Sub Category Markers are updated for S3 Tests

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
@seagate-sarang-sawant  Please add following markers in global list
s3_user_management
s3_bucket_acl
s3_object_acl
s3_audit_logs
s3_auth_health
s3_bucket_location
s3_bucket_policy
s3_bucket_tags
s3_bucket_ops
s3_object_copy
s3_data_durability
s3_data_path
s3_delete
s3_account_creds
s3_scalability
s3_iam_account
s3_iam_user_auth
s3_iam_user_mgnt
s3_object_ops
s3_multipart_ops
s3_object_tags
s3_openldap
s3_bucket_put
s3_acc_mgnt_key
s3_acc_mgnt_pwd
s3_concurrency
s3_faulttolerance
s3_support_bundle

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide