### PR TITLE
User-defined metadata keys always stored in lowercase

### DIFF
--- a/tests/cft/test_system_limit.py
+++ b/tests/cft/test_system_limit.py
@@ -714,10 +714,10 @@ class TestS3IOSystemLimits:
                     res = S3_TEST_OBJ.object_info(bucket_name, object_name)
                     assert_utils.assert_true(res[0], res[1])
                     assert_utils.assert_in("Metadata", res[1], res[1])
-                    assert_utils.assert_in(m_key, res[1]["Metadata"], res[1]["Metadata"])
+                    assert_utils.assert_in(m_key.lower(), res[1]["Metadata"], res[1]["Metadata"])
                     assert_utils.assert_equals(m_value,
-                                               res[1]["Metadata"][m_key],
-                                               res[1]["Metadata"][m_key])
+                                               res[1]["Metadata"][m_key.lower()],
+                                               res[1]["Metadata"][m_key.lower()])
                 else:
                     self.log.error(f"Could not see exception while uploading object with "
                                    f"metadata size of {metadata} > {metadata_limit}")


### PR DESCRIPTION
> User-defined metadata is a set of key-value pairs. Amazon S3 stores user-defined metadata keys in lowercase.

From [AWS Docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html#object-metadata)

Test executed logs attached at: [EOS-24628](https://jts.seagate.com/browse/EOS-24628?focusedCommentId=2224300&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2224300)

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide