### PR TITLE
Fixed: s3bench url in data path validation

### DIFF
--- a/tests/s3/test_data_path_validation.py
+++ b/tests/s3/test_data_path_validation.py
@@ -148,7 +148,7 @@ class TestDataPathValidation:
             self.access_key,
             self.secret_key,
             bucket,
-            S3_CFG["s3_url"],
+            S3_CFG["s3b_url"],
             100,
             100,
             obj_prefix,


### PR DESCRIPTION
Signed-off-by: Vishal Dhobale <vishal.dhobale@seagate.com>

# Problem Statement
- Six datapath tests are failing due to wrong url passed to s3bench.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide