### PR TITLE
Fixed call_duration exception

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -613,14 +613,11 @@ def pytest_runtest_makereport(item, call):
     report = outcome.get_result()
     Globals.ALL_RESULT = report
     setattr(item, "rep_" + report.when, report)
-    try:
+    if hasattr(item, 'call_duration'):
         attr = getattr(item, 'call_duration')
-        LOGGER.info('Setting attribute call_duration')
-    except AttributeError as attr_error:
-        LOGGER.warning('Exception %s occurred', str(attr_error))
-        setattr(item, "call_duration", call.duration)
-    else:
         setattr(item, "call_duration", call.duration + attr)
+    else:
+        setattr(item, "call_duration", call.duration)
 
     _local = bool(item.config.option.local)
     Globals.LOCAL_RUN = _local


### PR DESCRIPTION
# Problem Statement
- Observing following warning in test execution log
> [2021-12-16 12:33:56] [MainThread] [WARNING] [conftest.py: 620]: Exception 'Function' object has no attribute 'call_duration' occurred

# Design
As part of fix, removed `try catch` and used `hasattr` instead

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide