### PR TITLE
Added the additional param in execute_cmd call for deploy,destroy com…

### DIFF
--- a/libs/prov/prov_k8s_cortx_deploy.py
+++ b/libs/prov/prov_k8s_cortx_deploy.py
@@ -249,7 +249,12 @@ class ProvDeployK8sCortxLib:
             resp = node_obj.execute_cmd(cmd, read_lines=True, recv_ready=True, timeout=7200)
             LOGGER.debug("\n".join(resp).replace("\\n", "\n"))
             return True, resp
-        except BaseException as error:
+        except TimeoutError as error:
+            LOGGER.error(error, "7200")
+            node_obj.kill_remote_process(cmd)
+
+        except Exception as error:
+            LOGGER.exception(error)
             return False, error
 
     @staticmethod
@@ -328,6 +333,7 @@ class ProvDeployK8sCortxLib:
             with open(local_path, 'r') as file:
                 lines = file.read()
                 LOGGER.debug(lines)
+
         if resp[0]:
             LOGGER.info("Validate cluster status using status-cortx-cloud.sh")
             resp = self.validate_cluster_status(master_node_list[0],
@@ -724,7 +730,7 @@ class ProvDeployK8sCortxLib:
         try:
             if not master_node_obj.path_exists(custom_repo_path):
                 raise Exception(f"Repo path {custom_repo_path} does not exist")
-            resp = master_node_obj.execute_cmd(cmd=destroy_cmd, recv_ready=True, timeout=1200)
+            resp = master_node_obj.execute_cmd(cmd=destroy_cmd, recv_ready=True, timeout=900)
             LOGGER.debug("resp : %s", resp)
             for worker in worker_node_obj:
                 resp = worker.execute_cmd(cmd=list_etc_3rd_party, read_lines=True)


### PR DESCRIPTION
…mands

Signed-off-by: pragam <pragam.jain@seagate.com>

# Problem Statement
- Added the timeout,recv_ready param in execute_cmd call for deploy,destroy commands

# Design
-  For Bug, Describe the fix here.
-  For New test addition post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is formatted (e.g. using pycharm in-built formatter)

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --collect_only --local True`)
[collections_log.txt](https://github.com/Seagate/cortx-test/files/8131433/collections_log.txt)

# Review Checklist 
  Checklist for Author
-  [ ] JIRA number/GitHub Issue added to PR
-  [ ] PR is self reviewed
-  [ ] Jira and state/status is updated and JIRA is updated with PR link
-  [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe