### PR TITLE
Added fix for invoking status-cortx-cloud.sh

### DIFF
--- a/commons/commands.py
+++ b/commons/commands.py
@@ -529,7 +529,7 @@ CLSTR_STATUS_CMD = "cd {}; ./status-cortx-cloud.sh"
 CLSTR_LOGS_CMD = "cd {}; ./logs-cortx-cloud.sh"
 DEPLOY_CLUSTER_CMD = "cd {}; ./deploy-cortx-cloud.sh > {}"
 DESTROY_CLUSTER_CMD = "cd {}; ./destroy-cortx-cloud.sh --force"
-UPGRADE_CLUSTER_CMD = "cd {}; sh upgrade-cortx-cloud.sh -p {}"
+UPGRADE_CLUSTER_CMD = "cd {}; ./upgrade-cortx-cloud.sh -p {}"
 
 # Incomplete commands
 UPGRADE_NEG_CMD = "cd {}; sh upgrade-cortx-cloud.sh"

--- a/commons/commands.py
+++ b/commons/commands.py
@@ -525,9 +525,9 @@ HELM_GET_VALUES = "helm get values {}"
 # LC commands
 CLSTR_START_CMD = "cd {}; sh start-cortx-cloud.sh"
 CLSTR_STOP_CMD = "cd {}; sh shutdown-cortx-cloud.sh"
-CLSTR_STATUS_CMD = "cd {}; sh status-cortx-cloud.sh"
-CLSTR_LOGS_CMD = "cd {}; sh logs-cortx-cloud.sh"
-DEPLOY_CLUSTER_CMD = "cd {}; sh deploy-cortx-cloud.sh > {}"
+CLSTR_STATUS_CMD = "cd {}; ./status-cortx-cloud.sh"
+CLSTR_LOGS_CMD = "cd {}; ./logs-cortx-cloud.sh"
+DEPLOY_CLUSTER_CMD = "cd {}; ./deploy-cortx-cloud.sh > {}"
 DESTROY_CLUSTER_CMD = "cd {}; ./destroy-cortx-cloud.sh --force"
 UPGRADE_CLUSTER_CMD = "cd {}; sh upgrade-cortx-cloud.sh -p {}"
 

--- a/commons/commands.py
+++ b/commons/commands.py
@@ -532,7 +532,7 @@ DESTROY_CLUSTER_CMD = "cd {}; ./destroy-cortx-cloud.sh --force"
 UPGRADE_CLUSTER_CMD = "cd {}; ./upgrade-cortx-cloud.sh -p {}"
 
 # Incomplete commands
-UPGRADE_NEG_CMD = "cd {}; sh upgrade-cortx-cloud.sh"
+UPGRADE_NEG_CMD = "cd {}; ./upgrade-cortx-cloud.sh"
 
 CMD_POD_STATUS = "kubectl get pods"
 CMD_SRVC_STATUS = "kubectl get services"


### PR DESCRIPTION
Signed-off-by: pragam <pragam.jain@seagate.com>

# Problem Statement
- To Fix the invoking of status-cortx-cloud.sh script

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [x] Attach test execution logs
- https://eos-jenkins.colo.seagate.com/job/QA/job/K8s_Cortx_Continuous_Deployment/669/console
-  [x] Collection tested and no collection error introduced (`pytest --local True --collect-only`)
[collections_log.txt](https://github.com/Seagate/cortx-test/files/8329914/collections_log.txt)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide