### PR TITLE
Cortx 31619 add mort fixtures

### DIFF
--- a/comptests/motr/conftest.py
+++ b/comptests/motr/conftest.py
@@ -40,7 +40,7 @@ def run_m0_io(motr):
     This will run the motr IO using m0cp, m0cat, m0unlink utilities and returns the dict of objects
     """
     object_dict = None
-    cortx_node =None
+    cortx_node = None
     def _run_m0_io(node, bsize_layout_map=BSIZE_LAYOUT_MAP, block_count=FILE_BLOCK_COUNT,
                     run_m0cat=True, delete_objs=True):
         nonlocal object_dict, cortx_node

--- a/comptests/motr/conftest.py
+++ b/comptests/motr/conftest.py
@@ -24,8 +24,8 @@ from libs.motr import FILE_BLOCK_COUNT
 from libs.motr.layouts import BSIZE_LAYOUT_MAP
 from libs.motr.motr_core_k8s_lib import MotrCoreK8s
 
-@pytest.fixture(scope="module")
-def motr_inst():
+@pytest.fixture(name="motr", scope="module")
+def motr_lib_object():
     """
     To initiate the motr core lib instance
     """
@@ -35,7 +35,7 @@ def motr_inst():
 
 
 @pytest.fixture(scope="function")
-def run_m0_io(motr_inst):
+def run_m0_io(motr):
     """
     This will run the motr IO using m0cp, m0cat, m0unlink utilities and returns the dict of objects
     """
@@ -44,11 +44,11 @@ def run_m0_io(motr_inst):
     def _run_m0_io(node, bsize_layout_map=BSIZE_LAYOUT_MAP, block_count=FILE_BLOCK_COUNT,
                     run_m0cat=True, delete_objs=True):
         nonlocal object_dict, cortx_node
-        obj_dict = motr_inst.run_motr_io(node, bsize_layout_map, block_count, run_m0cat, delete_objs)
+        obj_dict = motr.run_motr_io(node, bsize_layout_map, block_count, run_m0cat, delete_objs)
         object_dict = obj_dict
         cortx_node = node
         return obj_dict
     yield _run_m0_io
     for obj in object_dict:
         if not object_dict[obj]['deleted']:
-            motr_inst.unlink_cmd(obj, object_dict[obj]['block_size'], cortx_node)
+            motr.unlink_cmd(obj, object_dict[obj]['block_size'], cortx_node)

--- a/comptests/motr/conftest.py
+++ b/comptests/motr/conftest.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# !/usr/bin/python
+#
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+"""This file contains motr Pytest fixtures"""
+
+import pytest
+from libs.motr import FILE_BLOCK_COUNT
+from libs.motr.layouts import BSIZE_LAYOUT_MAP
+from libs.motr.motr_core_k8s_lib import MotrCoreK8s
+
+@pytest.fixture(scope="module")
+def motr():
+    """
+    To initiate the motr core lib instance
+    """
+    obj = MotrCoreK8s()
+    yield obj
+    del obj
+
+
+@pytest.fixture(scope="function")
+def run_m0_io(motr):
+    """
+    This will run the motr IO using m0cp, m0cat, m0unlink utilities and returns the dict of objects
+    """
+    object_dict = None
+    cortx_node =None
+    def _run_m0_io(node, bsize_layout_map=BSIZE_LAYOUT_MAP, block_count=FILE_BLOCK_COUNT,
+                    run_m0cat=True, delete_objs=True):
+        nonlocal object_dict, cortx_node
+        obj_dict = motr.run_motr_io(node, bsize_layout_map, block_count, run_m0cat, delete_objs)
+        object_dict = obj_dict
+        cortx_node = node
+        return obj_dict
+    yield _run_m0_io
+    for obj in object_dict:
+        if object_dict[obj]['deleted'] == False:
+            motr.unlink_cmd(obj, object_dict[obj]['block_size'], cortx_node)

--- a/comptests/motr/conftest.py
+++ b/comptests/motr/conftest.py
@@ -25,7 +25,7 @@ from libs.motr.layouts import BSIZE_LAYOUT_MAP
 from libs.motr.motr_core_k8s_lib import MotrCoreK8s
 
 @pytest.fixture(scope="module")
-def motr():
+def motr_inst():
     """
     To initiate the motr core lib instance
     """
@@ -35,20 +35,20 @@ def motr():
 
 
 @pytest.fixture(scope="function")
-def run_m0_io(motr):
+def run_m0_io(motr_inst):
     """
     This will run the motr IO using m0cp, m0cat, m0unlink utilities and returns the dict of objects
     """
-    object_dict = None
+    object_dict = {}
     cortx_node = None
     def _run_m0_io(node, bsize_layout_map=BSIZE_LAYOUT_MAP, block_count=FILE_BLOCK_COUNT,
                     run_m0cat=True, delete_objs=True):
         nonlocal object_dict, cortx_node
-        obj_dict = motr.run_motr_io(node, bsize_layout_map, block_count, run_m0cat, delete_objs)
+        obj_dict = motr_inst.run_motr_io(node, bsize_layout_map, block_count, run_m0cat, delete_objs)
         object_dict = obj_dict
         cortx_node = node
         return obj_dict
     yield _run_m0_io
     for obj in object_dict:
-        if object_dict[obj]['deleted'] == False:
-            motr.unlink_cmd(obj, object_dict[obj]['block_size'], cortx_node)
+        if not object_dict[obj]['deleted']:
+            motr_inst.unlink_cmd(obj, object_dict[obj]['block_size'], cortx_node)

--- a/comptests/motr/test_motr_k8s_sanity.py
+++ b/comptests/motr/test_motr_k8s_sanity.py
@@ -241,7 +241,7 @@ class TestExecuteK8Sanity:
         return_dict = multiprocessing.Manager().dict()
         for node in self.motr_obj.cortx_node_list:
             node_process = multiprocessing.Process(target=self.motr_obj.run_io_in_parallel,
-                args=[node, [4], False, True, return_dict])
+                args=[node, BSIZE_LAYOUT_MAP, [4], False, True, return_dict])
             node_process.start()
         logger.info("Let the motr IO run on all the nodes for 120 sec")
         time.sleep(120)

--- a/libs/motr/motr_core_k8s_lib.py
+++ b/libs/motr/motr_core_k8s_lib.py
@@ -546,39 +546,47 @@ class MotrCoreK8s():
         self.dd_cmd(b_size.upper(), str(count), source_file, node)
         config_utils.write_yaml(config_file, m0cfg, backup=False, sort_keys=False)
 
-    def run_motr_io(self, node, block_count=FILE_BLOCK_COUNT, run_m0cat=True, delete_objs=True):
+    def run_motr_io(self, node, bsize_layout_map=BSIZE_LAYOUT_MAP, block_count=FILE_BLOCK_COUNT,
+                    run_m0cat=True, delete_objs=True):
         """
         Run m0cp, m0cat and m0unlink on a node for all the motr clients and returns the objects
         :param: str node: Cortx node on which utilities to be executed
+        :param: dict bsize_layout_map: mapping of block size and layout for IOs to run
         :param: list block_count: List containing the integer values. If block count is 1,
                 then size of object file will vary from 4K to 32M,
                 i.e multiple of supported object block sizes
         :param: bool run_m0cat: if True, will also run m0cat and compares the md5sum
         :param: bool delete_objs: if True, will delete the created objects
-        :return: object dictionary containing objects block size, md5sum and delete flag
+        :return: object dictionary containing objects block size, count, md5sum and delete flag
+                {'10:20':{'block_size':'4k', 'deleted': False, 'count': 4,
+                'md5sum': '2322f8a66f9eab2925e90182bad21dae'},
+                '10:21':{'block_size':'8k', 'deleted': False, 'count': 1,
+                'md5sum': 'bcf5e0570940a834455b6c5d449af5a7'}
+                }
         :rtype: dict
         """
         object_dict = {}
-        infile = TEMP_PATH + 'input'
-        outfile = TEMP_PATH + 'output'
+        infile = TEMP_PATH + '/input'
+        outfile = TEMP_PATH + '/output'
         try:
             for count in block_count:
-                for b_size in BSIZE_LAYOUT_MAP.keys():
+                for b_size in bsize_layout_map.keys():
                     object_id = str(SystemRandom().randint(1, 9999)) + ":" + \
                                     str(SystemRandom().randint(1, 9999))
                     object_dict[object_id] = {'block_size' : b_size }
                     object_dict[object_id]['deleted'] = False
+                    object_dict[object_id]['count'] = count
                     self.dd_cmd(b_size, str(count), infile, node)
-                    self.cp_cmd(b_size, str(count), object_id, BSIZE_LAYOUT_MAP[b_size],
+                    self.cp_cmd(b_size, str(count), object_id, bsize_layout_map[b_size],
                         infile, node)
                     if run_m0cat:
                         self.cat_cmd(b_size, str(count), object_id,
-                            BSIZE_LAYOUT_MAP[b_size], outfile, node)
+                            bsize_layout_map[b_size], outfile, node)
                         md5sum = self.get_md5sum(outfile, node)
                         object_dict[object_id]['md5sum'] = md5sum
                         self.md5sum_cmd(infile, outfile, node)
                     if delete_objs:
-                        self.unlink_cmd(object_id, BSIZE_LAYOUT_MAP[b_size], node)
+                        self.unlink_cmd(object_id, bsize_layout_map[b_size], node)
                         object_dict[object_id]['deleted'] = True
             return object_dict
         except Exception as exc:

--- a/libs/motr/motr_core_k8s_lib.py
+++ b/libs/motr/motr_core_k8s_lib.py
@@ -560,7 +560,7 @@ class MotrCoreK8s():
         :return: object dictionary containing objects block size, count, md5sum and delete flag
                 {'10:20':{'block_size':'4k', 'deleted': False, 'count': 4,
                 'md5sum': '2322f8a66f9eab2925e90182bad21dae'},
-                '10:21':{'block_size':'8k', 'deleted': False, 'count': 1,
+                '10:21':{'block_size':'8k', 'deleted': False, 'count': 2,
                 'md5sum': 'bcf5e0570940a834455b6c5d449af5a7'}
                 }
         :rtype: dict

--- a/libs/motr/motr_core_k8s_lib.py
+++ b/libs/motr/motr_core_k8s_lib.py
@@ -593,10 +593,11 @@ class MotrCoreK8s():
             log.exception("Test has failed with execption: %s", exc)
             raise exc
 
-    def run_io_in_parallel(self, node, block_count=FILE_BLOCK_COUNT,
-                        run_m0cat=True, delete_objs=True, return_dict=None):
+    def run_io_in_parallel(self, node, bsize_layout_map=BSIZE_LAYOUT_MAP,
+            block_count=FILE_BLOCK_COUNT, run_m0cat=True, delete_objs=True, return_dict=None):
         """
         :param: str node: Cortx node on which utilities to be executed
+        :param: dict bsize_layout_map: mapping of block size and layout for IOs to run
         :param: list block_count: List containing the integer values. If block count is 1,
                 then size of object file will vary from 4K to 32M,
                 i.e multiple of supported object block sizes
@@ -607,7 +608,7 @@ class MotrCoreK8s():
         if return_dict is None:
             return_dict = {}
         try:
-            obj_dict = self.run_motr_io(node, block_count, run_m0cat, delete_objs)
+            obj_dict = self.run_motr_io(node, bsize_layout_map, block_count, run_m0cat, delete_objs)
             return_dict[node] = obj_dict
             return return_dict
         except (OSError, AssertionError, IOError) as exc:


### PR DESCRIPTION
# Problem Statement
- Added conftest.py which contains motr fixtures that help to create objects by running m0cp and returns the dict of created objects with their md5sum and other details of block size and block count

# Design
-  For Bug, Describe the fix here.

# Coding
   Checklist for Author
-  [*] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [*] Attach test execution logs
[Test_execution.log](https://github.com/Seagate/cortx-test/files/8796263/Test_execution.log)
-  [*] Collection tested and no collection error introduced (`pytest --local True --collect-only`)
[CORTX-31619.zip](https://github.com/Seagate/cortx-test/files/8796258/CORTX-31619.zip)

# Review Checklist 
  Checklist for Author
- [*] JIRA number/GitHub Issue added to PR
- [*] PR is self reviewed
- [*] Jira and state/status is updated and JIRA is updated with PR link
- [*] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide