### PR TITLE
CORTX-31852 - fix for netstat based scan

### DIFF
--- a/tests/security/test_cortx_port_scanner_netstat.py
+++ b/tests/security/test_cortx_port_scanner_netstat.py
@@ -66,7 +66,7 @@ def test_cortx_port_scanner_netstat():
     ret = client.CoreV1Api().list_pod_for_all_namespaces(watch=False)
     for item in ret.items:
         LOGGER.info("%s\t%s\t%s", item.status.pod_ip,item.metadata.namespace,item.metadata.name)
-        if "cortx" in item.metadata.name:
+        if item.metadata.name in ("cortx-data", "cortx-ha", "cortx-server", "cortx-control"):
             LOGGER.info(" --------------------------------------")
             for list_each_con in item.spec.containers:
                 LOGGER.info(" Open Ports for Container: %s",list_each_con.name)


### PR DESCRIPTION
Signed-off-by: swanand-gadre <swanand.s.gadre@seagate.com>

# Problem Statement
- Problem statement

cortx port scanner - netstat scanning test is failing.
This failure is because earlier, netstat scan was running on all the PODs with cortx prefix.
With new services framework cortx- prefix is also attached to PODs like kafka, zookeeper.
netstat scans will not work for kafka, zookeeper.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

As fix, cortx-test/tests/securitytest_cortx_port_scanner_netstat.py script is updated with appropriate condition.

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [X] New/Affected tests are executed on Latest Build
-  [X] Attach test execution logs
-  [X] Collection tested and no collection error introduced (`pytest --local True --collect-only`)
Test results are attached to the bug -> https://jts.seagate.com/browse/CORTX-31852

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide

Not applicable