### PR TITLE
create multipart upload with tagging

### DIFF
--- a/config/s3/s3_object_test.yaml
+++ b/config/s3/s3_object_test.yaml
@@ -681,3 +681,12 @@ test_7657:
   bucket_name: "objworkflow7657"
   no_of_objects: 1010
   del_obj_cnt: 1000
+test_42776:
+  object_tag: "testkey=organizationCreateatagwhosekeyisupto128UnicodecharactersinlengtCreateatagwhosekeyisupto128Unicodecharacterslengthshouldbe128charorganizationCreateatagwhosekeyisupto128UnicodecharactersinlengtCreateatagwhosekeyisupto128Unicodecharacterslengthshouldbe128char"
+  tag_count: 1
+test_42777:
+  object_tag: "organizationCreateatagwhosekeyisupto128UnicodecharactersinlengtCreateatagwhosekeyisupto128Unicodecharacterslengthshouldbe128char=valuekey"
+  tag_count: 1
+test_42778:
+  object_tag: "tEsTkeY=TESTVALUE&TeSteEy=testvalue"
+  tag_count: 2

--- a/tests/s3/test_object_tagging.py
+++ b/tests/s3/test_object_tagging.py
@@ -21,6 +21,7 @@
 import os
 import logging
 import time
+import urllib.parse
 
 import pytest
 
@@ -1461,3 +1462,316 @@ class TestObjectTagging:
             resp[1]['TagCount'], S3_OBJ_TST["test_9419"]["tag_count"], resp[1])
         self.log.info("Object is Retrieved using GET object")
         self.log.info("verify Get object tags count using GET object on non tagged object")
+
+    @pytest.mark.parallel
+    @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
+    @pytest.mark.tags("TEST-42774")
+    @CTFailOn(error_handler)
+    def test_multipartupload_with_max_tags_42774(self):
+        """Verify Multipart Upload with max no. of tags"""
+        self.log.info(
+            "Verify Multipart Upload with max no.of tags for an Object")
+        self.log.info("Creating a bucket with name %s",
+                      self.bucket_name)
+        resp = self.s3_test_obj.create_bucket(
+            self.bucket_name)
+        assert resp[0], resp[1]
+        assert resp[1] == self.bucket_name, resp[1]
+        self.log.info(
+            "Bucket is created with name %s",
+            self.bucket_name)
+        self.log.info("Creating multipart upload with tagging")
+        resp = self.tag_obj.create_multipart_upload_with_tagging(
+            self.bucket_name,
+            self.object_name,
+            S3_OBJ_TST["test_9437"]["object_tag"])
+        assert (resp[0]), resp[1]
+        self.log.info("Created multipart upload with tagging support")
+        self.log.info("Performing list multipart uploads")
+        resp = self.s3_mp_obj.list_multipart_uploads(
+            self.bucket_name)
+        assert resp[0], resp[1]
+        upload_id = resp[1]["Uploads"][0]["UploadId"]
+        self.log.info(
+            "Performed list multipart upload on a bucket %s",
+            self.bucket_name)
+        self.log.info("Uploading parts to a bucket %s",
+                      self.bucket_name)
+        resp = self.s3_mp_obj.upload_parts(
+            upload_id,
+            self.bucket_name,
+            self.object_name,
+            S3_OBJ_TST["test_9418"]["single_part_size"],
+            total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
+            multipart_obj_path=self.file_path)
+        assert resp[0], resp[1]
+        upload_parts_list = resp[1]
+        self.log.info(
+            "Parts are uploaded to a bucket %s",
+            self.bucket_name)
+        self.log.info(
+            "Performing list parts of object %s",
+            self.object_name)
+        resp = self.s3_mp_obj.list_parts(upload_id,
+                                         self.bucket_name,
+                                         self.object_name)
+        assert resp[0], resp[1]
+        self.log.info("Performed list parts operation")
+        self.log.info(
+            "Performing complete multipart upload on a bucket %s",
+            self.bucket_name)
+        resp = self.s3_mp_obj.complete_multipart_upload(
+            upload_id,
+            upload_parts_list,
+            self.bucket_name,
+            self.object_name)
+        assert resp[0], resp[1]
+        self.log.info(
+            "Performed complete multipart upload on a bucket %s",
+            self.bucket_name)
+        self.log.info("Retrieving tag of an object")
+        resp = self.tag_obj.get_object_tags(
+            self.bucket_name,
+            self.object_name)
+        assert resp[0], resp[1]
+        assert len(resp[1]) == S3_OBJ_TST["test_9437"]["tag_count"], resp[1]
+        self.log.info("Retrieved tag of an object")
+        self.log.info("Verify Multipart Upload with tagging support")
+
+    @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
+    @pytest.mark.tags("TEST-42775")
+    @CTFailOn(error_handler)
+    def test_mpupload_with_valid_tagkeyspecialchars_42775(self):
+        """Verify Multipart Upload with tag key having valid special characters"""
+        self.log.info(
+            "Verify Multipart Upload with tag key having valid special characters")
+        self.log.info("Creating a bucket with name %s",
+                      self.bucket_name)
+        resp = self.s3_test_obj.create_bucket(
+            self.bucket_name)
+        assert resp[0], resp[1]
+        assert resp[1] == self.bucket_name, resp[1]
+        self.log.info(
+            "Bucket is created with name %s",
+            self.bucket_name)
+        self.log.info("Creating multipart upload with valid special characters in tag key")
+        tag = urllib.parse.urlencode({
+            S3_OBJ_TST["test_9429"]["key"]: S3_OBJ_TST["test_9429"]["value"]})
+        resp = self.tag_obj.create_multipart_upload_with_tagging(
+            self.bucket_name,
+            self.object_name,
+            tag)
+        assert (resp[0]), resp[1]
+        self.log.info("Created multipart upload with tagging support")
+        self.log.info("Performing list multipart uploads")
+        resp = self.s3_mp_obj.list_multipart_uploads(
+            self.bucket_name)
+        assert resp[0], resp[1]
+        upload_id = resp[1]["Uploads"][0]["UploadId"]
+        self.log.info(
+            "Performed list multipart upload on a bucket %s",
+            self.bucket_name)
+        self.log.info("Uploading parts to a bucket %s",
+                      self.bucket_name)
+        resp = self.s3_mp_obj.upload_parts(
+            upload_id,
+            self.bucket_name,
+            self.object_name,
+            S3_OBJ_TST["test_9418"]["single_part_size"],
+            total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
+            multipart_obj_path=self.file_path)
+        assert resp[0], resp[1]
+        upload_parts_list = resp[1]
+        self.log.info(
+            "Parts are uploaded to a bucket %s",
+            self.bucket_name)
+        self.log.info(
+            "Performing list parts of object %s",
+            self.object_name)
+        resp = self.s3_mp_obj.list_parts(upload_id,
+                                         self.bucket_name,
+                                         self.object_name)
+        assert resp[0], resp[1]
+        self.log.info("Performed list parts operation")
+        self.log.info(
+            "Performing complete multipart upload on a bucket %s",
+            self.bucket_name)
+        resp = self.s3_mp_obj.complete_multipart_upload(
+            upload_id,
+            upload_parts_list,
+            self.bucket_name,
+            self.object_name)
+        assert resp[0], resp[1]
+        self.log.info(
+            "Performed complete multipart upload on a bucket %s",
+            self.bucket_name)
+        self.log.info("Retrieving tag of an object %s",
+                      self.object_name)
+        resp = self.tag_obj.get_object_tags(
+            self.bucket_name,
+            self.object_name)
+        assert resp[0], (resp[1] ==
+                         {S3_OBJ_TST["test_9429"]["key"]: S3_OBJ_TST["test_9429"]["value"]})
+        self.log.info("Retrieved tag of an object")
+        self.log.info("Verify Multipart Upload with tag key having valid special characters")
+
+    @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
+    @pytest.mark.tags("TEST-42776")
+    @CTFailOn(error_handler)
+    def test_mpupload_with_tagvalue256chars_42776(self):
+        """Verify Multipart Upload with tag having
+        tag values up to 256 Unicode characters in length"""
+        self.log.info("Verify Multipart Upload with tag having "
+                      "tag values up to 256 Unicode characters in length")
+        self.log.info("Creating a bucket with name %s",
+                      self.bucket_name)
+        resp = self.s3_test_obj.create_bucket(
+            self.bucket_name)
+        assert resp[0], resp[1]
+        assert resp[1] == self.bucket_name, resp[1]
+        self.log.info(
+            "Bucket is created with name %s",
+            self.bucket_name)
+        self.log.info("Creating multipart upload with valid special characters in tag key")
+        tag = urllib.parse.urlencode(
+            {S3_OBJ_TST["s3_object"]["key"]: S3_OBJ_TST["test_9425"]["value"]})
+        resp = self.tag_obj.create_multipart_upload_with_tagging(
+            self.bucket_name,
+            self.object_name,
+            tag)
+        assert (resp[0]), resp[1]
+        self.log.info("Created multipart upload with tagging support")
+        self.log.info("Performing list multipart uploads")
+        resp = self.s3_mp_obj.list_multipart_uploads(
+            self.bucket_name)
+        assert resp[0], resp[1]
+        upload_id = resp[1]["Uploads"][0]["UploadId"]
+        self.log.info(
+            "Performed list multipart upload on a bucket %s",
+            self.bucket_name)
+        self.log.info("Uploading parts to a bucket %s",
+                      self.bucket_name)
+        resp = self.s3_mp_obj.upload_parts(
+            upload_id,
+            self.bucket_name,
+            self.object_name,
+            S3_OBJ_TST["test_9418"]["single_part_size"],
+            total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
+            multipart_obj_path=self.file_path)
+        assert resp[0], resp[1]
+        upload_parts_list = resp[1]
+        self.log.info(
+            "Parts are uploaded to a bucket %s",
+            self.bucket_name)
+        self.log.info(
+            "Performing list parts of object %s",
+            self.object_name)
+        resp = self.s3_mp_obj.list_parts(upload_id,
+                                         self.bucket_name,
+                                         self.object_name)
+        assert resp[0], resp[1]
+        self.log.info("Performed list parts operation")
+        self.log.info(
+            "Performing complete multipart upload on a bucket %s",
+            self.bucket_name)
+        resp = self.s3_mp_obj.complete_multipart_upload(
+            upload_id,
+            upload_parts_list,
+            self.bucket_name,
+            self.object_name)
+        assert resp[0], resp[1]
+        self.log.info(
+            "Performed complete multipart upload on a bucket %s",
+            self.bucket_name)
+        self.log.info("Retrieving tag of an object %s",
+                      self.object_name)
+        resp = self.tag_obj.get_object_tags(
+            self.bucket_name,
+            self.object_name)
+        assert resp[0], (resp[1] ==
+                         {S3_OBJ_TST["s3_object"]["key"]: S3_OBJ_TST["test_9425"]["value"]})
+        self.log.info("Retrieved tag of an object")
+        self.log.info("Verify Multipart Upload with tag having "
+                      "tag values up to 256 Unicode characters in length")
+
+    @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
+    @pytest.mark.tags("TEST-42777")
+    @CTFailOn(error_handler)
+    def test_mpupload_with_tagkey128chars_42777(self):
+        """Verify Multipart Upload with tag having tag key up to 128 Unicode characters in length"""
+        self.log.info("Verify Multipart Upload with tag having "
+                      "tag key up to 128 Unicode characters in length")
+        self.log.info("Creating a bucket with name %s",
+                      self.bucket_name)
+        resp = self.s3_test_obj.create_bucket(
+            self.bucket_name)
+        assert resp[0], resp[1]
+        assert resp[1] == self.bucket_name, resp[1]
+        self.log.info(
+            "Bucket is created with name %s",
+            self.bucket_name)
+        self.log.info("Creating multipart upload with valid special characters in tag key")
+        tag = urllib.parse.urlencode(
+            {S3_OBJ_TST["test_9423"]["key"]: S3_OBJ_TST["test_9423"]["value"]})
+        resp = self.tag_obj.create_multipart_upload_with_tagging(
+            self.bucket_name,
+            self.object_name,
+            tag)
+        assert (resp[0]), resp[1]
+        self.log.info("Created multipart upload with tagging support")
+        self.log.info("Performing list multipart uploads")
+        resp = self.s3_mp_obj.list_multipart_uploads(
+            self.bucket_name)
+        assert resp[0], resp[1]
+        upload_id = resp[1]["Uploads"][0]["UploadId"]
+        self.log.info(
+            "Performed list multipart upload on a bucket %s",
+            self.bucket_name)
+        self.log.info("Uploading parts to a bucket %s",
+                      self.bucket_name)
+        resp = self.s3_mp_obj.upload_parts(
+            upload_id,
+            self.bucket_name,
+            self.object_name,
+            S3_OBJ_TST["test_9418"]["single_part_size"],
+            total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
+            multipart_obj_path=self.file_path)
+        assert resp[0], resp[1]
+        upload_parts_list = resp[1]
+        self.log.info(
+            "Parts are uploaded to a bucket %s",
+            self.bucket_name)
+        self.log.info(
+            "Performing list parts of object %s",
+            self.object_name)
+        resp = self.s3_mp_obj.list_parts(upload_id,
+                                         self.bucket_name,
+                                         self.object_name)
+        assert resp[0], resp[1]
+        self.log.info("Performed list parts operation")
+        self.log.info(
+            "Performing complete multipart upload on a bucket %s",
+            self.bucket_name)
+        resp = self.s3_mp_obj.complete_multipart_upload(
+            upload_id,
+            upload_parts_list,
+            self.bucket_name,
+            self.object_name)
+        assert resp[0], resp[1]
+        self.log.info(
+            "Performed complete multipart upload on a bucket %s",
+            self.bucket_name)
+        self.log.info("Retrieving tag of an object %s",
+                      self.object_name)
+        resp = self.tag_obj.get_object_tags(
+            self.bucket_name,
+            self.object_name)
+        assert resp[0], \
+            (resp[1] == {S3_OBJ_TST["test_9423"]["key"]: S3_OBJ_TST["test_9423"]["value"]})
+        self.log.info("Retrieved tag of an object")
+        self.log.info("Verify Multipart Upload with tag having "
+                      "tag key up to 128 Unicode characters in length")

--- a/tests/s3/test_object_tagging.py
+++ b/tests/s3/test_object_tagging.py
@@ -1467,232 +1467,140 @@ class TestObjectTagging:
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-42774")
-    @CTFailOn(error_handler)
-    def test_multipartupload_with_max_tags_42774(self):
+    def test_multipartupload_max_tags_42774(self):
         """Verify Multipart Upload with max no. of tags"""
-        self.log.info(
-            "Verify Multipart Upload with max no.of tags for an Object")
-        self.log.info("Creating a bucket with name %s",
-                      self.bucket_name)
-        resp = self.s3_test_obj.create_bucket(
-            self.bucket_name)
-        assert resp[0], resp[1]
-        assert resp[1] == self.bucket_name, resp[1]
-        self.log.info(
-            "Bucket is created with name %s",
-            self.bucket_name)
+        self.log.info("Verify Multipart Upload with max no.of tags for an Object")
+        self.log.info("Creating a bucket with name %s", self.bucket_name)
+        resp = self.s3_test_obj.create_bucket(self.bucket_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        assert_utils.assert_equal(resp[1], self.bucket_name, resp[1])
+        self.log.info("Bucket is created with name %s", self.bucket_name)
         self.log.info("Creating multipart upload with tagging")
-        resp = self.tag_obj.create_multipart_upload_with_tagging(
-            self.bucket_name,
-            self.object_name,
-            S3_OBJ_TST["test_9437"]["object_tag"])
-        assert (resp[0]), resp[1]
-        self.log.info("Created multipart upload with tagging support")
+        resp = self.tag_obj.create_multipart_upload_with_tagging(self.bucket_name,
+                                                                 self.object_name,
+                                                                 S3_OBJ_TST["test_9437"]["object_tag"])
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Created multipart upload with max no.of tags for an Object")
         self.log.info("Performing list multipart uploads")
-        resp = self.s3_mp_obj.list_multipart_uploads(
-            self.bucket_name)
-        assert resp[0], resp[1]
+        resp = self.s3_mp_obj.list_multipart_uploads(self.bucket_name)
+        assert_utils.assert_true(resp[0], resp[1])
         upload_id = resp[1]["Uploads"][0]["UploadId"]
-        self.log.info(
-            "Performed list multipart upload on a bucket %s",
-            self.bucket_name)
-        self.log.info("Uploading parts to a bucket %s",
-                      self.bucket_name)
-        resp = self.s3_mp_obj.upload_parts(
-            upload_id,
-            self.bucket_name,
-            self.object_name,
-            S3_OBJ_TST["test_9418"]["single_part_size"],
-            total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
-            multipart_obj_path=self.file_path)
-        assert resp[0], resp[1]
+        self.log.info("Performed list multipart upload on a bucket %s", self.bucket_name)
+        self.log.info("Uploading parts to a bucket %s", self.bucket_name)
+        resp = self.s3_mp_obj.upload_parts(upload_id, self.bucket_name, self.object_name,
+                                           S3_OBJ_TST["test_9418"]["single_part_size"],
+                                           total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
+                                           multipart_obj_path=self.file_path)
+        assert_utils.assert_true(resp[0], resp[1])
         upload_parts_list = resp[1]
-        self.log.info(
-            "Parts are uploaded to a bucket %s",
-            self.bucket_name)
-        self.log.info(
-            "Performing list parts of object %s",
-            self.object_name)
-        resp = self.s3_mp_obj.list_parts(upload_id,
-                                         self.bucket_name,
-                                         self.object_name)
-        assert resp[0], resp[1]
+        self.log.info("Parts are uploaded to a bucket %s", self.bucket_name)
+        self.log.info("Performing list parts of object %s", self.object_name)
+        resp = self.s3_mp_obj.list_parts(upload_id, self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
         self.log.info("Performed list parts operation")
-        self.log.info(
-            "Performing complete multipart upload on a bucket %s",
-            self.bucket_name)
-        resp = self.s3_mp_obj.complete_multipart_upload(
-            upload_id,
-            upload_parts_list,
-            self.bucket_name,
-            self.object_name)
-        assert resp[0], resp[1]
-        self.log.info(
-            "Performed complete multipart upload on a bucket %s",
-            self.bucket_name)
+        self.log.info("Performing complete multipart upload on a bucket %s", self.bucket_name)
+        resp = self.s3_mp_obj.complete_multipart_upload(upload_id, upload_parts_list,
+                                                        self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Performed complete multipart upload on a bucket %s", self.bucket_name)
         self.log.info("Retrieving tag of an object")
-        resp = self.tag_obj.get_object_tags(
-            self.bucket_name,
-            self.object_name)
-        assert resp[0], resp[1]
-        assert len(resp[1]) == S3_OBJ_TST["test_9437"]["tag_count"], resp[1]
+        resp = self.tag_obj.get_object_tags(self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        assert_utils.assert_equal(len(resp[1]), 10, resp[1])
         self.log.info("Retrieved tag of an object")
-        self.log.info("Verify Multipart Upload with tagging support")
+        self.log.info("Verify Multipart Upload with max no.of tags for an Object")
 
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-42775")
-    @CTFailOn(error_handler)
-    def test_mpupload_with_valid_tagkeyspecialchars_42775(self):
+    def test_mpupload_valid_tagkeyspecialchars_42775(self):
         """Verify Multipart Upload with tag key having valid special characters"""
-        self.log.info(
-            "Verify Multipart Upload with tag key having valid special characters")
-        self.log.info("Creating a bucket with name %s",
-                      self.bucket_name)
-        resp = self.s3_test_obj.create_bucket(
-            self.bucket_name)
-        assert resp[0], resp[1]
-        assert resp[1] == self.bucket_name, resp[1]
-        self.log.info(
-            "Bucket is created with name %s",
-            self.bucket_name)
-        self.log.info("Creating multipart upload with valid special characters in tag key")
+        self.log.info("Verify Multipart Upload with tag key having valid special characters")
+        self.log.info("Creating a bucket with name %s", self.bucket_name)
+        resp = self.s3_test_obj.create_bucket(self.bucket_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        assert_utils.assert_equal(resp[1], self.bucket_name, resp[1])
+        self.log.info("Bucket is created with name %s", self.bucket_name)
+        self.log.info("Creating multipart upload with tagging")
         tag = urllib.parse.urlencode({
             S3_OBJ_TST["test_9429"]["key"]: S3_OBJ_TST["test_9429"]["value"]})
-        resp = self.tag_obj.create_multipart_upload_with_tagging(
-            self.bucket_name,
-            self.object_name,
-            tag)
-        assert (resp[0]), resp[1]
-        self.log.info("Created multipart upload with tagging support")
+        resp = self.tag_obj.create_multipart_upload_with_tagging(self.bucket_name,
+                                                                 self.object_name, tag)
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Created multipart upload with tag key having valid special characters")
         self.log.info("Performing list multipart uploads")
-        resp = self.s3_mp_obj.list_multipart_uploads(
-            self.bucket_name)
-        assert resp[0], resp[1]
+        resp = self.s3_mp_obj.list_multipart_uploads(self.bucket_name)
+        assert_utils.assert_true(resp[0], resp[1])
         upload_id = resp[1]["Uploads"][0]["UploadId"]
-        self.log.info(
-            "Performed list multipart upload on a bucket %s",
-            self.bucket_name)
-        self.log.info("Uploading parts to a bucket %s",
-                      self.bucket_name)
-        resp = self.s3_mp_obj.upload_parts(
-            upload_id,
-            self.bucket_name,
-            self.object_name,
-            S3_OBJ_TST["test_9418"]["single_part_size"],
-            total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
-            multipart_obj_path=self.file_path)
-        assert resp[0], resp[1]
+        self.log.info("Performed list multipart upload on a bucket %s", self.bucket_name)
+        self.log.info("Uploading parts to a bucket %s", self.bucket_name)
+        resp = self.s3_mp_obj.upload_parts(upload_id, self.bucket_name, self.object_name,
+                                           S3_OBJ_TST["test_9418"]["single_part_size"],
+                                           total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
+                                           multipart_obj_path=self.file_path)
+        assert_utils.assert_true(resp[0], resp[1])
         upload_parts_list = resp[1]
-        self.log.info(
-            "Parts are uploaded to a bucket %s",
-            self.bucket_name)
-        self.log.info(
-            "Performing list parts of object %s",
-            self.object_name)
-        resp = self.s3_mp_obj.list_parts(upload_id,
-                                         self.bucket_name,
-                                         self.object_name)
-        assert resp[0], resp[1]
+        self.log.info("Parts are uploaded to a bucket %s", self.bucket_name)
+        self.log.info("Performing list parts of object %s", self.object_name)
+        resp = self.s3_mp_obj.list_parts(upload_id, self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
         self.log.info("Performed list parts operation")
-        self.log.info(
-            "Performing complete multipart upload on a bucket %s",
-            self.bucket_name)
-        resp = self.s3_mp_obj.complete_multipart_upload(
-            upload_id,
-            upload_parts_list,
-            self.bucket_name,
-            self.object_name)
-        assert resp[0], resp[1]
-        self.log.info(
-            "Performed complete multipart upload on a bucket %s",
-            self.bucket_name)
-        self.log.info("Retrieving tag of an object %s",
-                      self.object_name)
-        resp = self.tag_obj.get_object_tags(
-            self.bucket_name,
-            self.object_name)
-        assert resp[0], (resp[1] ==
-                         {S3_OBJ_TST["test_9429"]["key"]: S3_OBJ_TST["test_9429"]["value"]})
+        self.log.info("Performing complete multipart upload on a bucket %s", self.bucket_name)
+        resp = self.s3_mp_obj.complete_multipart_upload(upload_id, upload_parts_list,
+                                                        self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Performed complete multipart upload on a bucket %s", self.bucket_name)
+        self.log.info("Retrieving tag of an object %s", self.object_name)
+        resp = self.tag_obj.get_object_tags(self.bucket_name, self.object_name)
+        assert_utils.assert_equal(
+            resp[1], {S3_OBJ_TST["test_9429"]["key"]: S3_OBJ_TST["test_9429"]["value"]}, resp[1])
         self.log.info("Retrieved tag of an object")
         self.log.info("Verify Multipart Upload with tag key having valid special characters")
 
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-42776")
-    @CTFailOn(error_handler)
     def test_mpupload_with_tagvalue256chars_42776(self):
         """Verify Multipart Upload with tag having
         tag values up to 256 Unicode characters in length"""
         self.log.info("Verify Multipart Upload with tag having "
                       "tag values up to 256 Unicode characters in length")
-        self.log.info("Creating a bucket with name %s",
-                      self.bucket_name)
-        resp = self.s3_test_obj.create_bucket(
-            self.bucket_name)
-        assert resp[0], resp[1]
-        assert resp[1] == self.bucket_name, resp[1]
-        self.log.info(
-            "Bucket is created with name %s",
-            self.bucket_name)
-        self.log.info("Creating multipart upload with valid special characters in tag key")
-        tag = urllib.parse.urlencode(
-            {S3_OBJ_TST["s3_object"]["key"]: S3_OBJ_TST["test_9425"]["value"]})
+        self.log.info("Creating a bucket with name %s", self.bucket_name)
+        resp = self.s3_test_obj.create_bucket(self.bucket_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        assert_utils.assert_equal(resp[1], self.bucket_name, resp[1])
+        self.log.info("Bucket is created with name %s", self.bucket_name)
+        self.log.info("Creating multipart upload with tagging")
         resp = self.tag_obj.create_multipart_upload_with_tagging(
-            self.bucket_name,
-            self.object_name,
-            tag)
-        assert (resp[0]), resp[1]
-        self.log.info("Created multipart upload with tagging support")
+            self.bucket_name, self.object_name, S3_OBJ_TST["test_42776"]["object_tag"])
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info(
+            "Created multipart upload with tag values up to 256 Unicode characters in length")
         self.log.info("Performing list multipart uploads")
-        resp = self.s3_mp_obj.list_multipart_uploads(
-            self.bucket_name)
-        assert resp[0], resp[1]
+        resp = self.s3_mp_obj.list_multipart_uploads(self.bucket_name)
+        assert_utils.assert_true(resp[0], resp[1])
         upload_id = resp[1]["Uploads"][0]["UploadId"]
-        self.log.info(
-            "Performed list multipart upload on a bucket %s",
-            self.bucket_name)
-        self.log.info("Uploading parts to a bucket %s",
-                      self.bucket_name)
-        resp = self.s3_mp_obj.upload_parts(
-            upload_id,
-            self.bucket_name,
-            self.object_name,
-            S3_OBJ_TST["test_9418"]["single_part_size"],
-            total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
-            multipart_obj_path=self.file_path)
-        assert resp[0], resp[1]
+        self.log.info("Performed list multipart upload on a bucket %s", self.bucket_name)
+        self.log.info("Uploading parts to a bucket %s", self.bucket_name)
+        resp = self.s3_mp_obj.upload_parts(upload_id, self.bucket_name, self.object_name,
+                                           S3_OBJ_TST["test_9418"]["single_part_size"],
+                                           total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
+                                           multipart_obj_path=self.file_path)
+        assert_utils.assert_true(resp[0], resp[1])
         upload_parts_list = resp[1]
-        self.log.info(
-            "Parts are uploaded to a bucket %s",
-            self.bucket_name)
-        self.log.info(
-            "Performing list parts of object %s",
-            self.object_name)
-        resp = self.s3_mp_obj.list_parts(upload_id,
-                                         self.bucket_name,
-                                         self.object_name)
-        assert resp[0], resp[1]
+        self.log.info("Parts are uploaded to a bucket %s", self.bucket_name)
+        self.log.info("Performing list parts of object %s", self.object_name)
+        resp = self.s3_mp_obj.list_parts(upload_id, self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
         self.log.info("Performed list parts operation")
-        self.log.info(
-            "Performing complete multipart upload on a bucket %s",
-            self.bucket_name)
-        resp = self.s3_mp_obj.complete_multipart_upload(
-            upload_id,
-            upload_parts_list,
-            self.bucket_name,
-            self.object_name)
-        assert resp[0], resp[1]
-        self.log.info(
-            "Performed complete multipart upload on a bucket %s",
-            self.bucket_name)
-        self.log.info("Retrieving tag of an object %s",
-                      self.object_name)
-        resp = self.tag_obj.get_object_tags(
-            self.bucket_name,
-            self.object_name)
-        assert resp[0], (resp[1] ==
-                         {S3_OBJ_TST["s3_object"]["key"]: S3_OBJ_TST["test_9425"]["value"]})
+        self.log.info("Performing complete multipart upload on a bucket %s", self.bucket_name)
+        resp = self.s3_mp_obj.complete_multipart_upload(upload_id, upload_parts_list,
+                                                        self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Performed complete multipart upload on a bucket %s", self.bucket_name)
+        self.log.info("Retrieving tag of an object %s", self.object_name)
+        resp = self.tag_obj.get_object_tags(self.bucket_name, self.object_name)
+        assert_utils.assert_equal(len(resp[1]), S3_OBJ_TST["test_42776"]["tag_count"], resp[1])
         self.log.info("Retrieved tag of an object")
         self.log.info("Verify Multipart Upload with tag having "
                       "tag values up to 256 Unicode characters in length")
@@ -1700,78 +1608,91 @@ class TestObjectTagging:
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-42777")
-    @CTFailOn(error_handler)
-    def test_mpupload_with_tagkey128chars_42777(self):
+    def test_mpupload_tagkey128chars_42777(self):
         """Verify Multipart Upload with tag having tag key up to 128 Unicode characters in length"""
         self.log.info("Verify Multipart Upload with tag having "
                       "tag key up to 128 Unicode characters in length")
-        self.log.info("Creating a bucket with name %s",
-                      self.bucket_name)
-        resp = self.s3_test_obj.create_bucket(
-            self.bucket_name)
-        assert resp[0], resp[1]
-        assert resp[1] == self.bucket_name, resp[1]
-        self.log.info(
-            "Bucket is created with name %s",
-            self.bucket_name)
-        self.log.info("Creating multipart upload with valid special characters in tag key")
-        tag = urllib.parse.urlencode(
-            {S3_OBJ_TST["test_9423"]["key"]: S3_OBJ_TST["test_9423"]["value"]})
+        self.log.info("Creating a bucket with name %s", self.bucket_name)
+        resp = self.s3_test_obj.create_bucket(self.bucket_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        assert_utils.assert_equal(resp[1], self.bucket_name, resp[1])
+        self.log.info("Bucket is created with name %s", self.bucket_name)
+        self.log.info("Creating multipart upload with tagging")
         resp = self.tag_obj.create_multipart_upload_with_tagging(
-            self.bucket_name,
-            self.object_name,
-            tag)
-        assert (resp[0]), resp[1]
-        self.log.info("Created multipart upload with tagging support")
+            self.bucket_name, self.object_name, S3_OBJ_TST["test_42777"]["object_tag"])
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info(
+            "Created multipart upload with tag key up to 128 Unicode characters in length")
         self.log.info("Performing list multipart uploads")
-        resp = self.s3_mp_obj.list_multipart_uploads(
-            self.bucket_name)
-        assert resp[0], resp[1]
+        resp = self.s3_mp_obj.list_multipart_uploads(self.bucket_name)
+        assert_utils.assert_true(resp[0], resp[1])
         upload_id = resp[1]["Uploads"][0]["UploadId"]
-        self.log.info(
-            "Performed list multipart upload on a bucket %s",
-            self.bucket_name)
-        self.log.info("Uploading parts to a bucket %s",
-                      self.bucket_name)
-        resp = self.s3_mp_obj.upload_parts(
-            upload_id,
-            self.bucket_name,
-            self.object_name,
-            S3_OBJ_TST["test_9418"]["single_part_size"],
-            total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
-            multipart_obj_path=self.file_path)
-        assert resp[0], resp[1]
+        self.log.info("Performed list multipart upload on a bucket %s", self.bucket_name)
+        self.log.info("Uploading parts to a bucket %s", self.bucket_name)
+        resp = self.s3_mp_obj.upload_parts(upload_id, self.bucket_name, self.object_name,
+                                           S3_OBJ_TST["test_9418"]["single_part_size"],
+                                           total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
+                                           multipart_obj_path=self.file_path)
+        assert_utils.assert_true(resp[0], resp[1])
         upload_parts_list = resp[1]
-        self.log.info(
-            "Parts are uploaded to a bucket %s",
-            self.bucket_name)
-        self.log.info(
-            "Performing list parts of object %s",
-            self.object_name)
-        resp = self.s3_mp_obj.list_parts(upload_id,
-                                         self.bucket_name,
-                                         self.object_name)
-        assert resp[0], resp[1]
+        self.log.info("Parts are uploaded to a bucket %s", self.bucket_name)
+        self.log.info("Performing list parts of object %s", self.object_name)
+        resp = self.s3_mp_obj.list_parts(upload_id, self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
         self.log.info("Performed list parts operation")
-        self.log.info(
-            "Performing complete multipart upload on a bucket %s",
-            self.bucket_name)
-        resp = self.s3_mp_obj.complete_multipart_upload(
-            upload_id,
-            upload_parts_list,
-            self.bucket_name,
-            self.object_name)
-        assert resp[0], resp[1]
-        self.log.info(
-            "Performed complete multipart upload on a bucket %s",
-            self.bucket_name)
-        self.log.info("Retrieving tag of an object %s",
-                      self.object_name)
-        resp = self.tag_obj.get_object_tags(
-            self.bucket_name,
-            self.object_name)
-        assert resp[0], \
-            (resp[1] == {S3_OBJ_TST["test_9423"]["key"]: S3_OBJ_TST["test_9423"]["value"]})
+        self.log.info("Performing complete multipart upload on a bucket %s", self.bucket_name)
+        resp = self.s3_mp_obj.complete_multipart_upload(upload_id, upload_parts_list,
+                                                        self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Performed complete multipart upload on a bucket %s", self.bucket_name)
+        self.log.info("Retrieving tag of an object %s", self.object_name)
+        resp = self.tag_obj.get_object_tags(self.bucket_name, self.object_name)
+        assert_utils.assert_equal(len(resp[1]), S3_OBJ_TST["test_42777"]["tag_count"], resp[1])
         self.log.info("Retrieved tag of an object")
         self.log.info("Verify Multipart Upload with tag having "
                       "tag key up to 128 Unicode characters in length")
+
+    @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
+    @pytest.mark.tags("TEST-42778")
+    def test_mpupload_casesensitive_tag_42778(self):
+        """Verify Multipart Upload with tag Keys & value having case sensitive labels"""
+        self.log.info("Verify Multipart Upload with tag Keys & value having case sensitive labels")
+        self.log.info("Creating a bucket with name %s", self.bucket_name)
+        resp = self.s3_test_obj.create_bucket(self.bucket_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        assert_utils.assert_equal(resp[1], self.bucket_name, resp[1])
+        self.log.info("Bucket is created with name %s", self.bucket_name)
+        self.log.info("Creating multipart upload with tagging")
+        resp = self.tag_obj.create_multipart_upload_with_tagging(
+            self.bucket_name, self.object_name,
+            S3_OBJ_TST["test_42778"]["object_tag"])
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Created multipart upload with Keys & value having case sensitive labels")
+        self.log.info("Performing list multipart uploads")
+        resp = self.s3_mp_obj.list_multipart_uploads(self.bucket_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        upload_id = resp[1]["Uploads"][0]["UploadId"]
+        self.log.info("Performed list multipart upload on a bucket %s", self.bucket_name)
+        self.log.info("Uploading parts to a bucket %s", self.bucket_name)
+        resp = self.s3_mp_obj.upload_parts(upload_id, self.bucket_name, self.object_name,
+                                           S3_OBJ_TST["test_9418"]["single_part_size"],
+                                           total_parts=S3_OBJ_TST["test_9418"]["total_parts"],
+                                           multipart_obj_path=self.file_path)
+        assert_utils.assert_true(resp[0], resp[1])
+        upload_parts_list = resp[1]
+        self.log.info("Parts are uploaded to a bucket %s", self.bucket_name)
+        self.log.info("Performing list parts of object %s", self.object_name)
+        resp = self.s3_mp_obj.list_parts(upload_id, self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Performed list parts operation")
+        self.log.info("Performing complete multipart upload on a bucket %s", self.bucket_name)
+        resp = self.s3_mp_obj.complete_multipart_upload(upload_id, upload_parts_list,
+                                                        self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Performed complete multipart upload on a bucket %s", self.bucket_name)
+        self.log.info("Retrieving tag of an object %s", self.object_name)
+        resp = self.tag_obj.get_object_tags(self.bucket_name, self.object_name)
+        assert_utils.assert_equal(len(resp[1]), S3_OBJ_TST["test_42778"]["tag_count"], resp[1])
+        self.log.info("Retrieved tag of an object")
+        self.log.info("Verify Multipart Upload with tag Keys & value having case sensitive labels")


### PR DESCRIPTION
Signed-off-by: akshaym99 <akshay.s.mankar@seagate.com>

# Problem Statement
- Automate testcases for F28B: CreateMultipartUpload with tagging.
- TEST-42774, TEST-42775, TEST-42776, TEST-42777, TEST-42778

# Design
- TD: https://seagate-systems.atlassian.net/wiki/spaces/PRIVATECOR/pages/983465985/F-28B+S3+Object+Tagging+API 

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide