### PR TITLE
Cortx 31882 putobject tagging happy path

### DIFF
--- a/config/s3/s3_object_test.yaml
+++ b/config/s3/s3_object_test.yaml
@@ -581,7 +581,7 @@ test_9433:
 test_9434:
     bucket_name: "objtag9434"
     value: "testvalue"
-    object_count: 2
+    object_count: 50
     tag_count: 10
 test_9435:
     bucket_name: "objtag9435"

--- a/scripts/jenkins_job/get_tests_count.py
+++ b/scripts/jenkins_job/get_tests_count.py
@@ -29,6 +29,54 @@ from commons.utils import jira_utils
 
 # CSV file contain test count in sequence[total,passed,fail,skip,todo]
 TOTAL_COUNT_CSV = 'total_count.csv'
+CLONED_TE_CSV = 'cloned_tp_info.csv'
+TESTS_TE_CSV = 'te_tests_count.csv'
+
+
+def get_te_test_count(te_dict, jobject):
+    """
+    Get test count from TE
+
+    :param te_dict: Dictionary of TE
+    :param jobject: Jira Object
+    """
+    with open(os.path.join(os.getcwd(), TESTS_TE_CSV), 'w', newline='', encoding="utf8") as te_csv:
+        writer = csv.writer(te_csv)
+        for key, val in te_dict.items():
+            total = todo = passed = fail = skip = exe = 0
+            for test_exe_id in val:
+                res = jobject.get_test_details(test_exe_id)
+                for test in res:
+                    res = test
+                print(res)
+                total += len(res)
+                todo += len([test for test in res if test["status"] == 'TODO'])
+                passed += len([test for test in res if test["status"] == 'PASS'])
+                fail += len([test for test in res if test["status"] == 'FAIL'])
+                skip += len([test for test in res if test["status"] in ['SKIPPED', 'BLOCKED']])
+                exe += len([test for test in res if test["status"] == 'EXECUTING'])
+
+            writer.writerow([key, total, passed, fail, skip, todo, exe])
+
+
+def get_tp_test_count(test_plan, jira_id, jira_pass):
+    """
+    Get test count from TP
+
+    :param test_plan: TP ID
+    :param jira_id: Jira ID
+    :param jira_pass: Jira Password
+    """
+    res = jira_utils.JiraTask.get_test_list_from_test_plan(test_plan, jira_id, jira_pass)
+    total = len(res)
+    todo = len([test for test in res if test['latestStatus'] == 'TODO'])
+    passed = len([test for test in res if test['latestStatus'] == 'PASS'])
+    fail = len([test for test in res if test['latestStatus'] == 'FAIL'])
+    skip = len([test for test in res if test['latestStatus'] in ['SKIPPED', 'BLOCKED']])
+    exe = len([test for test in res if test['latestStatus'] == 'EXECUTING'])
+    with open(os.path.join(os.getcwd(), TOTAL_COUNT_CSV), 'w', newline='', encoding="utf8") as t_p:
+        writer = csv.writer(t_p)
+        writer.writerow([total, passed, fail, skip, todo, exe])
 
 
 def main():
@@ -36,23 +84,33 @@ def main():
     main function
     """
     parser = argparse.ArgumentParser(description="TODO count")
-    parser.add_argument("-tp", help="test plan", required=True)
+    parser.add_argument("-tp", help="test plan", required=False)
     parser.add_argument("-ji", help="jira password", required=True)
     parser.add_argument("-jp", help="jira id", required=True)
     args = parser.parse_args()
     test_plan_id = args.tp
     jira_password = args.jp
     jira_id = args.ji
-    res = jira_utils.JiraTask.get_test_list_from_test_plan(test_plan_id, jira_id, jira_password)
-    total = len(res)
-    todo = len([test for test in res if test['latestStatus'] == 'TODO'])
-    passed = len([test for test in res if test['latestStatus'] == 'PASS'])
-    fail = len([test for test in res if test['latestStatus'] == 'FAIL'])
-    skip = len([test for test in res if test['latestStatus'] in ['SKIPPED', 'BLOCKED']])
-    exe = len([test for test in res if test['latestStatus'] == 'EXECUTING'])
-    with open(os.path.join(os.getcwd(), TOTAL_COUNT_CSV), 'w', newline='') as tp_info_csv:
-        writer = csv.writer(tp_info_csv)
-        writer.writerow([total, passed, fail, skip, todo, exe])
+    if test_plan_id:
+        print("Inside TP")
+        get_tp_test_count(test_plan_id, jira_id, jira_password)
+    else:
+        print("Inside TE")
+        jobject = jira_utils.JiraTask(jira_id, jira_password)
+        original_te = {"TEST-37458": "Sanity_TE", "TEST-39283": "Data_Path_TE", "TEST-40061": "Failure_TE"}
+        # original_te = {"TEST-29156": "Sanity_TE", "TEST-40938": "Data_Path_TE",
+        #                "TEST-41594": "Failure_TE"}
+        dict_te = {"Sanity_TE": [], "Data_Path_TE": [], "Failure_TE": [], "Regre_TE": []}
+        with open(os.path.join(os.getcwd(), CLONED_TE_CSV), 'r', encoding="utf8") as file:
+            csvreader = csv.reader(file)
+            for row in csvreader:
+                if row[2] in original_te:
+                    k = original_te[row[2]]
+                    dict_te[k].append(row[1])
+                else:
+                    dict_te["Regre_TE"].append(row[1])
+        print("Dict is:", dict_te)
+        get_te_test_count(dict_te, jobject)
 
 
 if __name__ == "__main__":

--- a/tests/s3/test_object_tagging.py
+++ b/tests/s3/test_object_tagging.py
@@ -532,7 +532,7 @@ class TestObjectTagging:
             self.object_name,
             self.file_path,
             mb_count=S3_OBJ_TST["s3_object"]["mb_count"],
-            key=S3_OBJ_TST["s3_object"]["key"],
+            key=S3_OBJ_TST["test_9423"]["key"],
             value=S3_OBJ_TST["test_9423"]["value"])
         self.log.info(
             "Created a bucket, uploaded an object and tag is set for object")
@@ -760,7 +760,7 @@ class TestObjectTagging:
             self.object_name,
             self.file_path,
             mb_count=S3_OBJ_TST["s3_object"]["mb_count"],
-            key=S3_OBJ_TST["s3_object"]["key"],
+            key=S3_OBJ_TST["test_9429"]["key"],
             value=S3_OBJ_TST["test_9429"]["value"])
         self.log.info(
             "Created a bucket, uploaded an object and tag is set for object")
@@ -985,13 +985,12 @@ class TestObjectTagging:
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5562")
     @CTFailOn(error_handler)
-    def test_max_object_max_tags_2478(self):
-        """Verification of max. no. of Objects user can upload with max no. of tags per Object."""
-        self.log.info(
-            "Verification of max. no. of Objects user can upload with max no. of tags per Object")
-        self.log.info(
-            "Creating a bucket with name %s",
-            self.bucket_name)
+    def test_multiple_object_max_tags_2478(self):
+        """Verification of multiple no. of Objects user
+        can upload with max no. of tags per Object."""
+        self.log.info("Verification of multiple no. of Objects user can "
+                      "upload with max no. of tags per Object")
+        self.log.info("Creating a bucket with name %s", self.bucket_name)
         resp = self.s3_test_obj.create_bucket(
             self.bucket_name)
         assert resp[0], resp[1]


### PR DESCRIPTION
# Problem Statement
- Automate testcases for F28B: PutObjectTagging - Happy path

# Design
-  TD doc: https://seagate-systems.atlassian.net/wiki/spaces/PRIVATECOR/pages/983465985/F-28B+S3+Object+Tagging+API 

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide