### PR TITLE
two more test cases : TEST-40431, 40432

### DIFF
--- a/tests/s3/versioning/test_get_put_object_tagging.py
+++ b/tests/s3/versioning/test_get_put_object_tagging.py
@@ -141,7 +141,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name, version_id=latest_v)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -162,7 +162,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_v)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -173,7 +173,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -214,7 +214,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_v)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -227,7 +227,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -239,7 +239,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -260,7 +260,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name, version_id=latest_v)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -273,7 +273,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -284,7 +284,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -340,7 +340,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id1)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -353,6 +353,7 @@ class TestGetPutObjectTagging:
                                              version_tag=self.ver_tag, versions_dict=self.versions)
         assert_utils.assert_true(resp[0], resp)
 
+        put_tag = self.ver_tag[self.object_name][latest_ver_id1][-1]
         LOGGER.info("Step 7: Perform GET Object Tagging for %s with versionId=%s",
                     self.object_name, latest_ver_id1)
         resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
@@ -361,7 +362,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id1)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -372,7 +373,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -406,13 +407,14 @@ class TestGetPutObjectTagging:
 
         LOGGER.info("Step 12: Perform GET Object Tagging for %s with versionId=%s",
                     self.object_name, latest_ver_id1)
+        put_tag = self.ver_tag[self.object_name][latest_ver_id1][-1]
         resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
                                              s3_ver_test_obj=self.s3_ver_obj,
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name,
                                              version_id=latest_ver_id1)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -425,7 +427,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id2)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -436,7 +438,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -458,7 +460,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id1)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -471,7 +473,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id2)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -482,7 +484,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -566,7 +568,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id2)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -577,7 +579,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -600,7 +602,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id1)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -613,7 +615,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id2)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -624,7 +626,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -652,7 +654,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id1)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -665,7 +667,7 @@ class TestGetPutObjectTagging:
                                              object_name=self.object_name,
                                              version_id=latest_ver_id2)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -677,7 +679,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name, version_id=latest_v)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
@@ -688,7 +690,7 @@ class TestGetPutObjectTagging:
                                              bucket_name=self.bucket_name,
                                              object_name=self.object_name)
         assert_utils.assert_true(resp[0], resp)
-        get_tag = resp[1]['TagSet'][0]
+        get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 

--- a/tests/s3/versioning/test_get_put_object_tagging.py
+++ b/tests/s3/versioning/test_get_put_object_tagging.py
@@ -293,7 +293,7 @@ class TestGetPutObjectTagging:
 
     @pytest.mark.s3_ops
     @pytest.mark.tags("TEST-40431")
-    def test_get_put_obj_tags_bkt_40431(self):
+    def test_get_put_obj_tags_ver_bkt_40431(self):
         """Test GET and PUT object tagging in a versioning enabled bucket"""
 
         LOGGER.info("STARTED: Test GET and PUT object tagging in a versioning enabled bucket")
@@ -629,9 +629,9 @@ class TestGetPutObjectTagging:
                                                     f"Expected: {put_tag} \n Actual: {get_tag}")
 
         LOGGER.info("Step 13: Perform PUT Object for %s", self.object_name)
-        resp = self.s3_test_obj.put_object(bucket_name=self.bucket_name,
-                                           object_name=self.object_name)
-        assert_utils.assert_true(resp[0], resp[1])
+        s3_cmn_lib.upload_version(self.s3_test_obj, bucket_name=self.bucket_name,
+                                  object_name=self.object_name, file_path=self.file_path,
+                                  versions_dict=self.versions, chk_null_version=True)
 
         LOGGER.info("Step 14: Perform PUT Object Tagging for %s with a tag key-value "
                     "pair", self.object_name)

--- a/tests/s3/versioning/test_get_put_object_tagging.py
+++ b/tests/s3/versioning/test_get_put_object_tagging.py
@@ -290,3 +290,406 @@ class TestGetPutObjectTagging:
 
         LOGGER.info("ENDED: Test GET and PUT object tagging for pre-existing object in"
                     " a versioning enabled bucket ")
+
+    @pytest.mark.s3_ops
+    @pytest.mark.tags("TEST-40431")
+    def test_get_put_obj_tags_bkt_40431(self):
+        """Test GET and PUT object tagging in a versioning enabled bucket"""
+
+        LOGGER.info("STARTED: Test GET and PUT object tagging in a versioning enabled bucket")
+
+        LOGGER.info("Step 1: Perform PUT Bucket versioning with status as Enabled on %s",
+                    self.bucket_name)
+        resp = self.s3_ver_obj.put_bucket_versioning(bucket_name=self.bucket_name)
+        assert_utils.assert_true(resp[0], resp)
+
+        LOGGER.info("Step 2: Upload Object %s with version enabled bucket %s",
+                    self.object_name, self.bucket_name)
+        s3_cmn_lib.upload_version(self.s3_test_obj, bucket_name=self.bucket_name,
+                                  file_path=self.file_path, object_name=self.object_name,
+                                  versions_dict=self.versions)
+        latest_ver_id1 = self.versions[self.object_name]["version_history"][-1]
+
+        LOGGER.info("Step 3: Perform GET Object Tagging for %s with versionId=%s"
+                    "and check TagSet is empty", self.object_name, latest_ver_id1)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id1)
+        assert_utils.assert_true(resp[0], resp)
+        # For new version ID, expecting "TagSet": []
+        assert_utils.assert_false(resp[1], resp)
+
+        LOGGER.info("Step 4: Perform PUT Object Tagging for %s with a tag key-value pair"
+                    " with versionId=%s", self.object_name, latest_ver_id1)
+        resp = s3_cmn_lib.put_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_tag=self.ver_tag, versions_dict=self.versions,
+                                             version_id=latest_ver_id1)
+        assert_utils.assert_true(resp[0], resp)
+
+        LOGGER.info("Step 5: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_ver_id1)
+        put_tag = self.ver_tag[self.object_name][latest_ver_id1][-1]
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id1)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 6: Perform PUT Object Tagging for %s with a tag key-value pair",
+                    self.object_name)
+        resp = s3_cmn_lib.put_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_tag=self.ver_tag, versions_dict=self.versions)
+        assert_utils.assert_true(resp[0], resp)
+
+        LOGGER.info("Step 7: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_ver_id1)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id1)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 8: Perform GET Object Tagging for %s without versionId specified",
+                    self.object_name)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 9: Upload Object %s with version enabled bucket %s",
+                    self.object_name, self.bucket_name)
+        s3_cmn_lib.upload_version(self.s3_test_obj, bucket_name=self.bucket_name,
+                                  file_path=self.file_path, object_name=self.object_name,
+                                  versions_dict=self.versions)
+        latest_ver_id2 = self.versions[self.object_name]["version_history"][-1]
+
+        LOGGER.info("Step 10: Perform GET Object Tagging for %s with versionId=%s and "
+                    "check TagSet is empty", self.object_name, latest_ver_id2)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id2)
+        assert_utils.assert_true(resp[0], resp)
+        # For new version ID, expecting "TagSet": []
+        assert_utils.assert_false(resp[1], resp)
+
+        LOGGER.info("Step 11: Perform PUT Object Tagging for %s with a tag key-value pair"
+                    " with versionId=%s", self.object_name, latest_ver_id2)
+        resp = s3_cmn_lib.put_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_tag=self.ver_tag, versions_dict=self.versions,
+                                             version_id=latest_ver_id2)
+        assert_utils.assert_true(resp[0], resp)
+
+        LOGGER.info("Step 12: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_ver_id1)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id1)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 13: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_ver_id2)
+        put_tag = self.ver_tag[self.object_name][latest_ver_id2][-1]
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id2)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 14: Perform GET Object Tagging for %s without versionId specified",
+                    self.object_name)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 15: Perform PUT Object Tagging for %s with a tag key-value pair",
+                    self.object_name)
+        resp = s3_cmn_lib.put_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_tag=self.ver_tag, versions_dict=self.versions)
+        assert_utils.assert_true(resp[0], resp)
+
+        LOGGER.info("Step 16: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_ver_id1)
+        put_tag = self.ver_tag[self.object_name][latest_ver_id1][-1]
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id1)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 17: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_ver_id2)
+        put_tag = self.ver_tag[self.object_name][latest_ver_id2][-1]
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id2)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 18: Perform GET Object Tagging for %s without versionId specified",
+                    self.object_name)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("ENDED: Test GET and PUT object tagging in a versioning enabled bucket")
+
+    @pytest.mark.s3_ops
+    @pytest.mark.tags("TEST-40432")
+    def test_get_put_obj_tags_susp_bkt_40432(self):
+        """Test GET and PUT object tagging in a versioning suspended bucket"""
+
+        LOGGER.info("STARTED: Test GET and PUT object tagging in a versioning suspended bucket")
+
+        LOGGER.info("Step 1: Perform PUT Bucket versioning with status as Enabled on %s",
+                    self.bucket_name)
+        resp = self.s3_ver_obj.put_bucket_versioning(bucket_name=self.bucket_name)
+        assert_utils.assert_true(resp[0], resp)
+
+        LOGGER.info("Step 2: Upload Object %s with version enabled bucket %s",
+                    self.object_name, self.bucket_name)
+        s3_cmn_lib.upload_version(self.s3_test_obj, bucket_name=self.bucket_name,
+                                  file_path=self.file_path, object_name=self.object_name,
+                                  versions_dict=self.versions)
+        latest_ver_id1 = self.versions[self.object_name]["version_history"][-1]
+        s3_cmn_lib.upload_version(self.s3_test_obj, bucket_name=self.bucket_name,
+                                  file_path=self.file_path, object_name=self.object_name,
+                                  versions_dict=self.versions)
+        latest_ver_id2 = self.versions[self.object_name]["version_history"][-1]
+
+        LOGGER.info("Step 3: Perform PUT Bucket versioning with status as Suspended on %s",
+                    self.bucket_name)
+        resp = self.s3_ver_obj.put_bucket_versioning(bucket_name=self.bucket_name,
+                                                     status="Suspended")
+        assert_utils.assert_true(resp[0], resp)
+
+        LOGGER.info("Step 4: Perform GET Object Tagging for %s with versionId=%s and versionID=%s"
+                    "and check TagSet is empty", self.object_name, latest_ver_id1, latest_ver_id2)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id1)
+        assert_utils.assert_true(resp[0], resp)
+        # For new version ID, expecting "TagSet": []
+        assert_utils.assert_false(resp[1], resp)
+
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id2)
+        assert_utils.assert_true(resp[0], resp)
+        # For new version ID, expecting "TagSet": []
+        assert_utils.assert_false(resp[1], resp)
+
+        LOGGER.info("Step 5: Perform PUT Object Tagging for %s with a tag key-value "
+                    "pair", self.object_name)
+        resp = s3_cmn_lib.put_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_tag=self.ver_tag, versions_dict=self.versions)
+        assert_utils.assert_true(resp[0], resp)
+
+        LOGGER.info("Step 6: Perform GET Object Tagging for %s with versionId=%s"
+                    "and check TagSet is empty", self.object_name, latest_ver_id1)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id1)
+        assert_utils.assert_true(resp[0], resp)
+        # For new version ID, expecting "TagSet": []
+        assert_utils.assert_false(resp[1], resp)
+
+        LOGGER.info("Step 7: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_ver_id2)
+        put_tag = self.ver_tag[self.object_name][latest_ver_id2][-1]
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id2)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 8: Perform GET Object Tagging for %s without versionId specified",
+                    self.object_name)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 9: Perform PUT Object Tagging for %s with a tag key-value pair"
+                    " with versionId=%s", self.object_name, latest_ver_id1)
+        resp = s3_cmn_lib.put_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_tag=self.ver_tag, versions_dict=self.versions,
+                                             version_id=latest_ver_id1)
+        assert_utils.assert_true(resp[0], resp)
+
+        LOGGER.info("Step 10: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_ver_id1)
+        put_tag = self.ver_tag[self.object_name][latest_ver_id1][-1]
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id1)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 11: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_ver_id2)
+        put_tag = self.ver_tag[self.object_name][latest_ver_id2][-1]
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id2)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 12: Perform GET Object Tagging for %s without versionId specified",
+                    self.object_name)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 13: Perform PUT Object for %s", self.object_name)
+        resp = self.s3_test_obj.put_object(bucket_name=self.bucket_name,
+                                           object_name=self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+
+        LOGGER.info("Step 14: Perform PUT Object Tagging for %s with a tag key-value "
+                    "pair", self.object_name)
+        resp = s3_cmn_lib.put_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_tag=self.ver_tag, versions_dict=self.versions)
+        assert_utils.assert_true(resp[0], resp)
+        latest_v = self.versions[self.object_name]["version_history"][-1]
+
+        LOGGER.info("Step 15: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_ver_id1)
+        put_tag = self.ver_tag[self.object_name][latest_ver_id1][-1]
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id1)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 16: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_ver_id2)
+        put_tag = self.ver_tag[self.object_name][latest_ver_id2][-1]
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name,
+                                             version_id=latest_ver_id2)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 17: Perform GET Object Tagging for %s with versionId=%s",
+                    self.object_name, latest_v)
+        put_tag = self.ver_tag[self.object_name][latest_v][-1]
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name, version_id=latest_v)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("Step 18: Perform GET Object Tagging for %s without versionId specified",
+                    self.object_name)
+        resp = s3_cmn_lib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                             s3_ver_test_obj=self.s3_ver_obj,
+                                             bucket_name=self.bucket_name,
+                                             object_name=self.object_name)
+        assert_utils.assert_true(resp[0], resp)
+        get_tag = resp[1]['TagSet'][0]
+        assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+
+        LOGGER.info("ENDED: Test GET and PUT object tagging in a versioning suspended bucket")


### PR DESCRIPTION
Signed-off-by: RAHUL HATWAR <rahulchandrakant.hatwar@seagate.com>

# Problem Statement
TWO more test cases : TEST-40431 and TEST-40432

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide


Collection logs : 

ned_bucket_32729', 'test_id': 'TEST-32729', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[None]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Enabled]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Suspended]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_preexisting_32724', 'test_id': 'TEST-32724', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_enabled_32728', 'test_id': 'TEST-32728', 'marks': ['s3_ops', 'sanity']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_suspended_32733', 'test_id': 'TEST-32733', 'marks': ['s3_ops']}, {'nodeid': 'tests/security/test_cortx_port_scanner_kubectl_svc.py::test_cortx_port_scanner_kubectl_svc', 'test_id': 'TEST-34217', 'marks': ['security']}, {'nodeid': 'tests/security/test_cortx_port_scanner_netstat.py::test_cortx_port_scanner_netstat', 'test_id': 'TEST-34218', 'marks': ['security', 'skip']}] created at /root/workspace/cortx-test-1/log/te_meta.json
Successfully unmounted directory

========================================== 2261 tests collected in 9.91s ===========================================