### PR TITLE
TA for DeleteObjectTagging & Get object tags count using get-object

### DIFF
--- a/tests/s3/test_object_tagging.py
+++ b/tests/s3/test_object_tagging.py
@@ -29,6 +29,7 @@ from commons import error_messages as errmsg
 from commons.errorcodes import error_handler
 from commons.exceptions import CTException
 from commons.params import TEST_DATA_FOLDER
+from commons.utils import assert_utils
 from commons.utils.system_utils import create_file
 from commons.utils.system_utils import make_dirs
 from commons.utils.system_utils import path_exists
@@ -1387,3 +1388,77 @@ class TestObjectTagging:
                 error.message), error.message
         self.log.info(
             "Verify get object with tagging support to non-existing object")
+
+    @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
+    @pytest.mark.tags("TEST-42780")
+    def test_delobj_tagging_42780(self):
+        """Verify already deleted tag using DELETE object tagging."""
+        self.log.info("Verify already deleted tag using DELETE object tagging")
+        self.log.info("Creating a bucket, uploading an object and setting tag for object")
+        self.create_put_set_object_tag(self.bucket_name, self.object_name, self.file_path,
+                                       mb_count=S3_OBJ_TST["s3_object"]["mb_count"],
+                                       key=S3_OBJ_TST["s3_object"]["key"],
+                                       value=S3_OBJ_TST["test_9415"]["value"])
+        self.log.info("Created a bucket, uploaded an object and tag is set for object")
+        self.log.info("Retrieving tag of an object %s", self.object_name)
+        resp = self.tag_obj.get_object_tags(self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Retrieved tag of an object")
+        self.log.info("Deleting tag of an object")
+        resp = self.tag_obj.delete_object_tagging(self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Deleting already deleted tag")
+        try:
+            self.tag_obj.delete_object_tagging(self.bucket_name, self.object_name)
+        except CTException as error:
+            assert_utils.assert_in(S3_OBJ_TST["s3_object"]["key_err"], str(error.message),
+                                   error.message)
+        self.log.info("verifying tag of same object after DELETE object tagging")
+        resp = self.tag_obj.get_object_tags(self.bucket_name, self.object_name)
+        assert_utils.assert_equal(len(resp[1]), S3_OBJ_TST["test_9415"]["tag_length"], resp[1])
+        self.log.info("Verify already deleted tag using DELETE object tagging")
+
+    @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
+    @pytest.mark.tags("TEST-42781")
+    def test_object_tag_count_get_object_42781(self):
+        """ verify Get object tags count using GET object on non tagged object"""
+        self.log.info("verify Get object tags count using GET object on non tagged object")
+        self.log.info("Creating a bucket with name %s", self.bucket_name)
+        resp = self.s3_test_obj.create_bucket(self.bucket_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        assert_utils.assert_equal(resp[1], self.bucket_name, resp[1])
+        self.log.info("Bucket is created with name %s", self.bucket_name)
+        create_file(self.file_path, S3_OBJ_TST["s3_object"]["mb_count"])
+        self.log.info("Uploading an object %s", self.object_name)
+        resp = self.s3_test_obj.put_object(self.bucket_name, self.object_name, self.file_path)
+        assert_utils.assert_true(resp[0], resp[1])
+        self.log.info("Object is uploaded to a bucket")
+        self.log.info("Getting uploaded object")
+        resp = self.s3_test_obj.get_object(self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        assert_utils.assert_equal(resp[1]['TagCount'], 0, resp[1])
+        self.log.info("Object is Retrieved using GET object")
+        self.log.info("verify Get object tags count using GET object on non tagged object")
+
+    @pytest.mark.s3_ops
+    @pytest.mark.s3_object_tags
+    @pytest.mark.tags("TEST-42782")
+    def test_object_tag_count_get_object_42782(self):
+        """ verify Get object tags count using GET object on tagged object"""
+        self.log.info("verify Get object tags count using GET object on tagged object")
+        self.log.info("Creating a bucket, uploading an object and setting 10 tags for object")
+        self.create_put_set_object_tag(self.bucket_name, self.object_name, self.file_path,
+                                       mb_count=S3_OBJ_TST["s3_object"]["mb_count"],
+                                       key=S3_OBJ_TST["s3_object"]["key"],
+                                       value=S3_OBJ_TST["test_9419"]["value"],
+                                       tag_count=S3_OBJ_TST["test_9419"]["tag_count"])
+        self.log.info("Created a bucket, uploading an object and setting tags for object")
+        self.log.info("Getting uploaded object")
+        resp = self.s3_test_obj.get_object(self.bucket_name, self.object_name)
+        assert_utils.assert_true(resp[0], resp[1])
+        assert_utils.assert_equal(
+            resp[1]['TagCount'], S3_OBJ_TST["test_9419"]["tag_count"], resp[1])
+        self.log.info("Object is Retrieved using GET object")
+        self.log.info("verify Get object tags count using GET object on non tagged object")


### PR DESCRIPTION
Signed-off-by: akshaym99 <akshay.s.mankar@seagate.com>

# Problem Statement
- Test Automation for F-28B: DeleteObjectTagging & Get object tags count using get-object
-  TEST-42780, TEST-42781, TEST-42782

# Design
-  TD doc: https://seagate-systems.atlassian.net/wiki/spaces/PRIVATECOR/pages/983465985/F-28B+S3+Object+Tagging+API 

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide