### PR TITLE
Cortx-29601: RBF for Object tagging versioning

### DIFF
--- a/config/s3/s3_config.yaml
+++ b/config/s3/s3_config.yaml
@@ -75,4 +75,5 @@ delay:
   set_obj_tag: 15
   del_obj_tag: 20
 
-object_tagging_special_char: ["+", "-", "=", ".", "_", ":", "/", "@"]
+object_tagging_special_char_cortx: ["+", "-", "=", ".", "_", ":", "/", "@"]
+object_tagging_special_char_rgw: ["~", "`", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "-", "_", "+", "=", ";", ":", "|", "\\", ":", ";", "\"", "'", "<", ",", ">", ".", "?", "/"]

--- a/tests/s3/versioning/test_delete_object_tagging.py
+++ b/tests/s3/versioning/test_delete_object_tagging.py
@@ -519,7 +519,6 @@ class TestTaggingDeleteObject:
                                    bucket_name=self.bucket_name, object_name=self.object_name,
                                    versions_dict=self.versions, check_deletemarker=True)
         dm_id = self.versions[self.object_name]["delete_markers"][0]
-        assert_utils.assert_in("No Content", resp[1].message)
         LOGGER.info("Step 5: Performed DELETE Object  %s and created versionId(delete market id)="
                     "%s", self.object_name, str(dm_id))
         LOGGER.info("Step 6: Perform DELETE Object tagging  %s with versionId %s",
@@ -591,10 +590,10 @@ class TestTaggingDeleteObject:
         LOGGER.info("Step 4: Perform GET Object Tagging for %s with versionId=%s",
                     self.object_name, latest_v)
         put_tag = self.ver_tag[self.object_name][latest_v][-1]
-        resp = s3_ver_tlib.delete_object_tagging(bucket_name=self.bucket_name,
-                                                 s3_ver_test_obj=self.s3_ver_obj,
-                                                 s3_tag_test_obj=self.s3_tag_obj,
-                                                 object_name=self.object_name, version_id=latest_v)
+        resp = s3_ver_tlib.get_object_tagging(s3_tag_test_obj=self.s3_tag_obj,
+                                              s3_ver_test_obj=self.s3_ver_obj,
+                                              bucket_name=self.bucket_name,
+                                              object_name=self.object_name, version_id=latest_v)
         assert_utils.assert_true(resp[0], resp)
         get_tag = resp[1][0]
         assert_utils.assert_equal(get_tag, put_tag, "Mismatch in tag Key-Value pair."

--- a/tests/s3/versioning/test_limits_tagging_versioning.py
+++ b/tests/s3/versioning/test_limits_tagging_versioning.py
@@ -23,6 +23,7 @@
 import logging
 import os
 import time
+import random
 
 import pytest
 
@@ -474,11 +475,12 @@ class TestObjectTaggingVerLimits:
         LOGGER.info("Step 2: Successfully uploaded object %s to versioned bucket %s with "
                     "version ID %s", self.object_name, self.bucket_name, latest_ver)
         if S3_ENGINE_RGW == CMN_CFG["s3_engine"]:
-            list_special_char = S3_CFG["object_tagging_special_char_rgw"]
+            list_special_char = random.sample(S3_CFG["object_tagging_special_char_rgw"],10)
         else:
-            list_special_char = S3_CFG["object_tagging_special_char_cortx"]
+            list_special_char = random.sample(S3_CFG["object_tagging_special_char_cortx"],10)
         for char in list_special_char:
             tag_or = list()
+            put_tag = []
             tag_key = f"tag{char}key"
             tag_or.append({"Key": tag_key, "Value": "tag1value"})
             LOGGER.info("Step 3: Perform PUT Object Tagging for %s with tag set as %s with tag key "
@@ -503,9 +505,8 @@ class TestObjectTaggingVerLimits:
                                                 object_name=self.object_name, version_id=latest_ver)
             assert_utils.assert_true(resp[0], resp)
             get_tag = resp[1]
-            for pair in put_tag:
-                assert_utils.assert_in(pair, get_tag, "Mismatch in tag Key-Value pair."
-                                                    f"Expected: {put_tag} \n Actual: {get_tag}")
+            assert_utils.assert_equals(get_tag, put_tag, "Mismatch in tag Key-Value pair."
+                                                        f"Expected: {put_tag} \n Actual: {get_tag}")
             LOGGER.info("Step 4: Performed GET Object Tagging for %s with versionId=%s is %s",
                         self.object_name, latest_ver, get_tag)
         #Since all sprcial characters are allowed in RGW, following part of code is invalid


### PR DESCRIPTION
# Problem Statement
- RBF for object tagging versioning test cases.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [x] Attach test execution logs
-  [x] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide