### PR TITLE
S3 test additions for CICD sanity and text fixes

### DIFF
--- a/libs/s3/s3_versioning_common_test_lib.py
+++ b/libs/s3/s3_versioning_common_test_lib.py
@@ -266,6 +266,7 @@ def check_get_head_object_version(s3_test_obj: S3TestLib, s3_ver_test_obj: S3Ver
                                                   skip_polling=True)
         assert_utils.assert_true(get_response[0], get_response[1])
         if version_id:
+            assert_utils.assert_in("VersionId", get_response[1].keys())
             assert_utils.assert_equal(get_response[1]["VersionId"], version_id)
         if etag:
             assert_utils.assert_equal(get_response[1]["ETag"], etag)
@@ -285,6 +286,7 @@ def check_get_head_object_version(s3_test_obj: S3TestLib, s3_ver_test_obj: S3Ver
             head_response = s3_test_obj.object_info(bucket_name=bucket_name, key=object_name)
         assert_utils.assert_true(head_response[0], head_response[1])
         if version_id:
+            assert_utils.assert_in("VersionId", head_response[1].keys())
             assert_utils.assert_equal(head_response[1]["VersionId"], version_id)
         if etag:
             assert_utils.assert_equal(head_response[1]["ETag"], etag)

--- a/tests/s3/test_bucket_tagging.py
+++ b/tests/s3/test_bucket_tagging.py
@@ -127,6 +127,7 @@ class TestBucketTagging:
         self.log.info("Step 3: Retrieved tag of a bucket")
         self.log.info("ENDED: Verify GET Bucket tagging")
 
+    @pytest.mark.sanity
     @pytest.mark.parallel
     @pytest.mark.s3_ops
     @pytest.mark.s3_bucket_tags

--- a/tests/s3/test_object_tagging.py
+++ b/tests/s3/test_object_tagging.py
@@ -123,6 +123,7 @@ class TestObjectTagging:
         assert_utils.assert_equal(resp[1], self.bucket_name, resp[1])
         self.log.info("Bucket is created with name %s", self.bucket_name)
 
+    @pytest.mark.sanity
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5549")
@@ -141,6 +142,7 @@ class TestObjectTagging:
         self.log.info("Retrieved tag of an object")
         self.log.info("Verify PUT object tagging")
 
+    @pytest.mark.sanity
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5557")
@@ -159,6 +161,7 @@ class TestObjectTagging:
         self.log.info("Retrieved tag of an object")
         self.log.info("Verify GET object tagging")
 
+    @pytest.mark.sanity
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5561")
@@ -183,6 +186,7 @@ class TestObjectTagging:
         self.log.info("Verified that tags are deleted")
         self.log.info("Verify DELETE object tagging")
 
+    @pytest.mark.sanity
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_tags
     @pytest.mark.usefixtures("create_bucket")
@@ -223,6 +227,7 @@ class TestObjectTagging:
         self.log.info("Retrieved tag of an object")
         self.log.info("Verify get object with tagging support")
 
+    @pytest.mark.sanity
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_tags
     @pytest.mark.regression
@@ -1038,6 +1043,7 @@ class TestObjectTagging:
         self.log.info("Object is Retrieved using GET object")
         self.log.info("verify Get object tags count using GET object on non tagged object")
 
+    @pytest.mark.sanity
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-42782")

--- a/tests/s3/versioning/test_delete_object_tagging.py
+++ b/tests/s3/versioning/test_delete_object_tagging.py
@@ -179,6 +179,7 @@ class TestTaggingDeleteObject:
                     "enabled bucket")
 
     # pylint:disable-msg=too-many-statements
+    @pytest.mark.sanity
     @pytest.mark.s3_ops
     @pytest.mark.tags("TEST-40436")
     @CTFailOn(error_handler)

--- a/tests/s3/versioning/test_versioning_delete_object.py
+++ b/tests/s3/versioning/test_versioning_delete_object.py
@@ -191,6 +191,7 @@ class TestVersioningDeleteObject:
                                       head_error_msg=errmsg.NOT_FOUND_ERR)
         self.log.info("ENDED: Test DELETE Object with pre-existing objects in a versioned bucket")
 
+    @pytest.mark.sanity
     @pytest.mark.s3_ops
     @pytest.mark.tags("TEST-32717")
     @CTFailOn(error_handler)

--- a/tests/s3/versioning/test_versioning_delete_objects.py
+++ b/tests/s3/versioning/test_versioning_delete_objects.py
@@ -153,6 +153,7 @@ class TestVersioningDeleteObjects:
                                           head_error_msg=errmsg.NOT_FOUND_ERR)
         self.log.info("ENDED: Test DELETE Objects for pre-existing objects in a versioned bucket")
 
+    @pytest.mark.sanity
     @pytest.mark.s3_ops
     @pytest.mark.tags("TEST-43188")
     def test_delete_objects_versioned_43188(self):

--- a/tests/s3/versioning/test_versioning_multipart.py
+++ b/tests/s3/versioning/test_versioning_multipart.py
@@ -114,6 +114,7 @@ class TestVersioningMultipart:
                                                     version_id="null", etag=etag)
         self.log.info("ENDED: Test pre-existing multipart upload in a versioning enabled bucket")
 
+    @pytest.mark.sanity
     @pytest.mark.s3_ops
     @pytest.mark.tags("TEST-41285")
     def test_mpu_ver_enabled_bkt_41285(self):


### PR DESCRIPTION
Signed-off-by: Apoorva Rao <apoorva.d.rao@seagate.com>

# Problem Statement
- Test additions for F-20F, F-33A and F-33C features into CICD sanity pipeline
- Test fixes for List Object Versions
- TEs used for verification - TEST-44022, TEST-44023 

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [x] New/Affected tests are executed on Latest Build
-  [x] Attach test execution logs
-  [x] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [x] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide