### PR TITLE
Optimize for multi server pod failure1(8 tests)

### DIFF
--- a/tests/ha/multi_pod_failure/test_multi_server_pod_failure.py
+++ b/tests/ha/multi_pod_failure/test_multi_server_pod_failure.py
@@ -184,10 +184,10 @@ class TestMultiServerPodFailure:
     @pytest.mark.tags("TEST-40567")
     def test_reads_kserver_pods_fail(self):
         """
-        Test to verify degraded READs after all K server pods down - unsafe shutdown.
+        Test to verify READs after all K server pods down - unsafe shutdown.
         """
-        LOGGER.info("Started: Test to verify degraded READs after all K server pods "
-                    "down - unsafe shutdown.")
+        LOGGER.info("Started: Test to verify READs after all K server pods down - unsafe "
+                    "shutdown.")
         LOGGER.info("STEP 1: Perform WRITEs/READs and Verify DI with variable object sizes.")
         users = self.mgnt_ops.create_account_users(nusers=1)
         self.test_prefix = 'test-40567'
@@ -224,8 +224,8 @@ class TestMultiServerPodFailure:
                                                     setup_s3bench=False)
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 3: Performed READs and verified DI on the written data")
-        LOGGER.info("Completed: Test to verify degraded READs after all K server pods "
-                    "down - unsafe shutdown.")
+        LOGGER.info("Completed: Test to verify READs after all K server pods down - unsafe "
+                    "shutdown.")
 
     # pylint: disable=too-many-statements
     @pytest.mark.ha
@@ -233,11 +233,10 @@ class TestMultiServerPodFailure:
     @pytest.mark.tags("TEST-40568")
     def test_reads_till_kserver_pods_fail(self):
         """
-        Test to verify degraded READs after each pod failure till K server pods "
-        "down - unsafe shutdown.
+        Test to verify READs after each pod failure till K server pods down - unsafe shutdown.
         """
-        LOGGER.info("Started: Test to verify degraded READs after each pod failure till K "
-                    "server pods down - unsafe shutdown.")
+        LOGGER.info("Started: Test to verify READs after each pod failure till K server pods down"
+                    " - unsafe shutdown.")
         LOGGER.info("STEP 1: Perform WRITEs/READs and Verify DI with variable object sizes.")
         users = self.mgnt_ops.create_account_users(nusers=1)
         self.test_prefix = 'test-40568'
@@ -278,8 +277,8 @@ class TestMultiServerPodFailure:
         LOGGER.info("Step 2: %s (K) server pods shutdown one by one successfully, Verified "
                     "cluster, services states are as expected & remaining pods status is online"
                     " and read/verify after each pod down verified", self.kvalue)
-        LOGGER.info("Completed: Test to verify degraded READs after each pod failure till K "
-                    "server pods down - unsafe shutdown.")
+        LOGGER.info("Completed: Test to verify READs after each pod failure till K server pods"
+                    " down - unsafe shutdown.")
 
     # pylint: disable=too-many-locals
     @pytest.mark.ha
@@ -287,7 +286,7 @@ class TestMultiServerPodFailure:
     @pytest.mark.tags("TEST-40573")
     def test_deletes_kserver_pods_fail(self):
         """
-        This test tests Degraded DELETEs after all K server pods down - unsafe shutdown
+        This test tests DELETEs after all K server pods down - unsafe shutdown
         """
         LOGGER.info("STARTED: Test to verify DELETEs after %s (K) server pods down - "
                     "unsafe shutdown", self.kvalue)
@@ -390,11 +389,10 @@ class TestMultiServerPodFailure:
     @pytest.mark.tags("TEST-40578")
     def test_writes_till_kserver_pods_fail(self):
         """
-        Test to verify degraded WRITEs after each pod failure till K server pods
-        down - unsafe shutdown.
+        Test to verify WRITEs after each pod failure till K server pods down - unsafe shutdown.
         """
-        LOGGER.info("Started: Test to verify degraded Writes after each pod failure till K "
-                    "server pods down - unsafe shutdown.")
+        LOGGER.info("Started: Test to verify Writes after each pod failure till K server pods "
+                    "down - unsafe shutdown.")
         LOGGER.info("STEP 1: Perform WRITEs-READs-Verify with variable object sizes.")
         users = self.mgnt_ops.create_account_users(nusers=1)
         self.test_prefix = 'test-40578'
@@ -448,8 +446,8 @@ class TestMultiServerPodFailure:
         LOGGER.info("Step 2: %s (K) server pods shutdown one by one successfully, Verify cluster,"
                     "services states are as expected & remaining pods status is online and WRITEs "
                     "after each server pod down on new and existing buckets verified", self.kvalue)
-        LOGGER.info("Completed: Test to verify degraded WRITEs after each pod failure till K "
-                    "server pods down - unsafe shutdown.")
+        LOGGER.info("Completed: Test to verify WRITEs after each pod failure till K server pods"
+                    " down - unsafe shutdown.")
 
     # pylint: disable=too-many-statements
     @pytest.mark.ha
@@ -457,10 +455,10 @@ class TestMultiServerPodFailure:
     @pytest.mark.tags("TEST-40579")
     def test_writes_kserver_pods_failure(self):
         """
-        Test to verify degraded WRITEs after all K server pods down - unsafe shutdown.
+        Test to verify WRITEs after all K server pods down - unsafe shutdown.
         """
-        LOGGER.info("Started: Test to verify degraded WRITEs after all K server pods "
-                    "down - unsafe shutdown.")
+        LOGGER.info("Started: Test to verify WRITEs after all K server pods down - unsafe "
+                    "shutdown.")
         LOGGER.info("STEP 1: Perform WRITEs-READs-Verify with variable object sizes.")
         users = self.mgnt_ops.create_account_users(nusers=1)
         self.test_prefix = 'test-40579'
@@ -507,8 +505,8 @@ class TestMultiServerPodFailure:
                                                     setup_s3bench=False)
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 4: Performed WRITEs-READs-Verify with variable sizes objects ")
-        LOGGER.info("Completed: Test to verify degraded WRITEs after all K server pods "
-                    "down - unsafe shutdown.")
+        LOGGER.info("Completed: Test to verify WRITEs after all K server pods down - unsafe "
+                    "shutdown.")
 
     # pylint: disable=too-many-statements
     @pytest.mark.ha
@@ -516,11 +514,10 @@ class TestMultiServerPodFailure:
     @pytest.mark.tags("TEST-40580")
     def test_deletes_till_kserver_pods_fail(self):
         """
-        Test to verify degraded DELETEs after each pod failure till K server pods
-        down - unsafe shutdown.
+        Test to verify DELETEs after each pod failure till K server pods down - unsafe shutdown.
         """
-        LOGGER.info("Started: Test to verify degraded Deletes after each pod failure till "
-                    "K server pods down - unsafe shutdown.")
+        LOGGER.info("Started: Test to verify Deletes after each pod failure till K server pods "
+                    "down - unsafe shutdown.")
         wr_bucket = self.kvalue * 5 + HA_CFG["s3_bucket_data"]["no_buckets_for_deg_deletes"]
         del_bucket = 20
         event = threading.Event()
@@ -622,8 +619,8 @@ class TestMultiServerPodFailure:
                     " services states are as expected & remaining pods status is online and "
                     "performed Deletes on random buckets and verified read on remaining bucket "
                     "after each server pod down", self.kvalue)
-        LOGGER.info("Completed: Test to verify degraded DELETEs after each pod failure till K "
-                    "server pods down - unsafe shutdown.")
+        LOGGER.info("Completed: Test to verify DELETEs after each pod failure till K server pods"
+                    " down - unsafe shutdown.")
 
     @pytest.mark.ha
     @pytest.mark.lc

--- a/tests/ha/multi_pod_failure/test_multi_server_pod_failure.py
+++ b/tests/ha/multi_pod_failure/test_multi_server_pod_failure.py
@@ -178,7 +178,6 @@ class TestMultiServerPodFailure:
 
         LOGGER.info("Done: Teardown completed.")
 
-    # pylint: disable=too-many-statements
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40567")
@@ -227,7 +226,6 @@ class TestMultiServerPodFailure:
         LOGGER.info("Completed: Test to verify READs after all K server pods down - unsafe "
                     "shutdown.")
 
-    # pylint: disable=too-many-statements
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40568")
@@ -281,6 +279,7 @@ class TestMultiServerPodFailure:
                     " down - unsafe shutdown.")
 
     # pylint: disable=too-many-locals
+    # pylint: disable=too-many-statements
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40573")
@@ -383,7 +382,6 @@ class TestMultiServerPodFailure:
         LOGGER.info("ENDED: Test to verify DELETEs after %s (K) server pods down"
                     " - unsafe shutdown.", self.kvalue)
 
-    # pylint: disable=too-many-statements
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40578")
@@ -449,7 +447,6 @@ class TestMultiServerPodFailure:
         LOGGER.info("Completed: Test to verify WRITEs after each pod failure till K server pods"
                     " down - unsafe shutdown.")
 
-    # pylint: disable=too-many-statements
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40579")
@@ -624,7 +621,6 @@ class TestMultiServerPodFailure:
 
     @pytest.mark.ha
     @pytest.mark.lc
-    @pytest.mark.skip(reason="Not supported in RGW yet")
     @pytest.mark.tags("TEST-40581")
     def test_copy_object_kserver_pods_fail(self):
         """
@@ -944,7 +940,6 @@ class TestMultiServerPodFailure:
                                                         multipart_obj_size=file_size,
                                                         total_parts=total_parts,
                                                         multipart_obj_path=object_path)
-
             assert_utils.assert_true(resp[0], f"Failed to upload parts {resp[1]}")
             LOGGER.info("Listing parts of partial multipart upload")
             res = s3_mp_test_obj.list_parts(mpu_id, self.bucket_name, self.object_name)
@@ -1716,7 +1711,6 @@ class TestMultiServerPodFailure:
 
     @pytest.mark.ha
     @pytest.mark.lc
-    @pytest.mark.skip(reason="Not supported in RGW yet")
     @pytest.mark.tags("TEST-40583")
     def test_copy_object_during_kserver_pods_down(self):
         """

--- a/tests/ha/multi_pod_failure/test_multi_server_pod_failure.py
+++ b/tests/ha/multi_pod_failure/test_multi_server_pod_failure.py
@@ -25,7 +25,7 @@ HA test suite for Multiple Server Pods Failure
 import copy
 import logging
 import os
-import random
+import secrets
 import threading
 import time
 from multiprocessing import Queue
@@ -36,8 +36,6 @@ from config import CMN_CFG
 from config import HA_CFG
 from config.s3 import S3_CFG
 from commons import constants as const
-from commons.ct_fail_on import CTFailOn
-from commons.errorcodes import error_handler
 from commons.helpers.health_helper import Health
 from commons.helpers.pods_helper import LogicalNode
 from commons.params import TEST_DATA_FOLDER
@@ -73,7 +71,6 @@ class TestMultiServerPodFailure:
         cls.num_nodes = len(CMN_CFG["nodes"])
         cls.username = []
         cls.password = []
-        cls.host_master_list = []
         cls.node_master_list = []
         cls.hlth_master_list = []
         cls.host_worker_list = []
@@ -81,19 +78,19 @@ class TestMultiServerPodFailure:
         cls.pod_name_list = []
         cls.ha_obj = HAK8s()
         cls.deploy_lc_obj = ProvDeployK8sCortxLib()
-        cls.s3_clean = cls.test_prefix = cls.random_time = None
+        cls.s3_clean = cls.test_prefix = cls.random_time = cls.multipart_obj_path = None
         cls.s3acc_name = cls.s3acc_email = cls.bucket_name = cls.object_name = None
         cls.restore_pod = cls.deployment_backup = cls.deployment_name = cls.restore_method = None
         cls.deploy = cls.kvalue = None
         cls.pod_dict = dict()
         cls.mgnt_ops = ManagementOPs()
+        cls.system_random = secrets.SystemRandom()
 
         for node in range(cls.num_nodes):
             cls.host = CMN_CFG["nodes"][node]["hostname"]
             cls.username.append(CMN_CFG["nodes"][node]["username"])
             cls.password.append(CMN_CFG["nodes"][node]["password"])
             if CMN_CFG["nodes"][node]["node_type"] == "master":
-                cls.host_master_list.append(cls.host)
                 cls.node_master_list.append(LogicalNode(hostname=cls.host,
                                                         username=cls.username[node],
                                                         password=cls.password[node]))
@@ -110,7 +107,6 @@ class TestMultiServerPodFailure:
         cls.s3_mp_test_obj = S3MultipartTestLib(endpoint_url=S3_CFG["s3_url"])
         cls.test_file = "ha-mp_obj"
         cls.test_dir_path = os.path.join(TEST_DATA_FOLDER, "HATestMultipartUpload")
-        cls.multipart_obj_path = None
 
     def setup_method(self):
         """
@@ -169,35 +165,11 @@ class TestMultiServerPodFailure:
                                                                    deployment_backup})
                 LOGGER.debug("Response: %s", resp)
                 assert_utils.assert_true(resp[0], "Failed to restore pod by "
-                                                  "{self.restore_method} way")
+                                                  f"{self.restore_method} way")
                 LOGGER.info("Successfully restored pod %s by %s way",
                             pod_name, self.restore_method)
         if os.path.exists(self.test_dir_path):
             sysutils.remove_dirs(self.test_dir_path)
-        # TODO: As cluster restart is not supported until F22A, Need to redeploy cluster after
-        #  every test
-        if self.deploy:
-            LOGGER.info("Cleanup: Destroying the cluster ")
-            resp = self.deploy_lc_obj.destroy_setup(self.node_master_list[0],
-                                                    self.node_worker_list,
-                                                    const.K8S_SCRIPTS_PATH)
-            assert_utils.assert_true(resp[0], resp[1])
-            LOGGER.info("Cleanup: Cluster destroyed successfully")
-
-            LOGGER.info("Cleanup: Setting prerequisite")
-            self.deploy_lc_obj.execute_prereq_cortx(self.node_master_list[0],
-                                                    const.K8S_SCRIPTS_PATH,
-                                                    const.K8S_PRE_DISK)
-            for node in self.node_worker_list:
-                self.deploy_lc_obj.execute_prereq_cortx(node, const.K8S_SCRIPTS_PATH,
-                                                        const.K8S_PRE_DISK)
-            LOGGER.info("Cleanup: Prerequisite set successfully")
-
-            LOGGER.info("Cleanup: Deploying the Cluster")
-            resp_cls = self.deploy_lc_obj.deploy_cluster(self.node_master_list[0],
-                                                         const.K8S_SCRIPTS_PATH)
-            assert_utils.assert_true(resp_cls[0], resp_cls[1])
-            LOGGER.info("Cleanup: Cluster deployment successfully")
 
         LOGGER.info("Cleanup: Check cluster status")
         resp = self.ha_obj.poll_cluster_status(self.node_master_list[0], timeout=180)
@@ -210,92 +182,48 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40567")
-    @CTFailOn(error_handler)
     def test_reads_kserver_pods_fail(self):
         """
         Test to verify degraded READs after all K server pods down - unsafe shutdown.
         """
         LOGGER.info("Started: Test to verify degraded READs after all K server pods "
                     "down - unsafe shutdown.")
-
-        LOGGER.info("STEP 1: Perform WRITEs with variable object sizes.")
+        LOGGER.info("STEP 1: Perform WRITEs/READs and Verify DI with variable object sizes.")
         users = self.mgnt_ops.create_account_users(nusers=1)
         self.test_prefix = 'test-40567'
         self.s3_clean = users
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                    log_prefix=self.test_prefix, skipread=True,
+                                                    log_prefix=self.test_prefix,
                                                     skipcleanup=True, nsamples=2, nclients=2)
         assert_utils.assert_true(resp[0], resp[1])
-        LOGGER.info("Step 1: Performed WRITEs with variable sizes objects.")
-
-        LOGGER.info("Step 2: Perform READs and verify DI on the written data")
-        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                    log_prefix=self.test_prefix, skipwrite=True,
-                                                    skipcleanup=True, nsamples=2, nclients=2)
-        assert_utils.assert_true(resp[0], resp[1])
-        LOGGER.info("Step 2: Performed READs and verified DI on the written data")
-
-        LOGGER.info("Step 3: Shutdown %s server pod by deleting deployment (unsafe)", self.kvalue)
-        LOGGER.info("Get server pod names to be deleted")
-        pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
-        LOGGER.info("Get data pod names")
-        data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
-        LOGGER.info("Combine data and server pods names")
-        server_data_pod_list = pod_list + data_pod_list
-
-        for count, pod_name in enumerate(self.pod_name_list):
-            count += 1
-            pod_data = []
-            LOGGER.info("Deleting %s pod %s", count, pod_name)
-            resp = self.node_master_list[0].delete_deployment(pod_name=pod_name)
-            LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_false(resp[0], f"Failed to delete {count} server pod {pod_name} "
-                                               " by deleting deployment (unsafe)")
-            pod_data.append(resp[1])  # deployment_backup
-            pod_data.append(resp[2])  # deployment_name
-            self.restore_pod = self.deploy = True
-            self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+        LOGGER.info("Step 1: Performed WRITEs/READs and Verify DI with variable sizes objects.")
+        LOGGER.info("Step 2: Shutdown random %s (K) server by deleting deployment and verify "
+                    "cluster & remaining pods status", self.kvalue)
+        resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+            master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+            pod_prefix=[const.SERVER_POD_NAME_PREFIX], down_method=const.RESTORE_DEPLOYMENT_K8S,
+            kvalue=self.kvalue)
+        assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+        for pod_name in resp[1].keys():
+            pod_data = list()
+            pod_data.append(resp[1][pod_name]['hostname'])  # hostname
+            pod_data.append(resp[1][pod_name]['deployment_backup'])
+            pod_data.append(resp[1][pod_name]['deployment_name'])
+            self.pod_name_list.append(pod_name)
             self.pod_dict[pod_name] = pod_data
-            LOGGER.info("Deleted %s server pod %s by deleting deployment (unsafe)", count,
-                        pod_name)
-        LOGGER.info("Step 3: Successfully deleted %s server pods", self.kvalue)
-
-        LOGGER.info("Step 4: Check cluster status")
-        resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
-        assert_utils.assert_false(resp[0], resp)
-        LOGGER.info("Step 4: Cluster has some failures due to %s server pods has gone down.",
-                    self.kvalue)
-
-        LOGGER.info("Step 5: Check services status that were running on server pods"
-                    " which are deleted.")
-        counter = 0
-        for pod_name in self.pod_name_list:
-            hostname = self.pod_dict.get(pod_name)[0]
-            resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=[pod_name], fail=True,
-                                                               hostname=hostname)
-            LOGGER.debug("Services status on %s : %s", pod_name, resp)
-            if not resp[0]:
-                counter += 1
-            server_data_pod_list.remove(pod_name)
-        assert_utils.assert_equal(counter, 0, "Services on some server pods not stopped.")
-        LOGGER.info("Step 5: Services of deleted server pods are in offline state")
-
-        LOGGER.info("Step 6: Check services status on remaining pods %s", server_data_pod_list)
-        resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=server_data_pod_list,
-                                                           fail=False)
-        LOGGER.debug("Response: %s", resp)
-        assert_utils.assert_true(resp[0], resp)
-        LOGGER.info("Step 6: Services of remaining pods %s are in "
-                    "online state", server_data_pod_list)
-
-        LOGGER.info("Step 7: Perform READs and verify DI on the written data")
+        self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("Step 2: Successfully shutdown random %s (K) server pod %s. Verified"
+                    " cluster and services states are as expected & remaining pods status "
+                    "is online.", self.kvalue, self.pod_name_list)
+        LOGGER.info("Step 3: Perform READs and verify DI on the written data")
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                     log_prefix=self.test_prefix, skipwrite=True,
-                                                    skipcleanup=True, nsamples=2, nclients=2)
+                                                    skipcleanup=True, nsamples=2, nclients=2,
+                                                    setup_s3bench=False)
         assert_utils.assert_true(resp[0], resp[1])
-        LOGGER.info("Step 7: Performed READs and verified DI on the written data")
-
+        LOGGER.info("Step 3: Performed READs and verified DI on the written data")
         LOGGER.info("Completed: Test to verify degraded READs after all K server pods "
                     "down - unsafe shutdown.")
 
@@ -303,7 +231,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40568")
-    @CTFailOn(error_handler)
     def test_reads_till_kserver_pods_fail(self):
         """
         Test to verify degraded READs after each pod failure till K server pods "
@@ -311,85 +238,46 @@ class TestMultiServerPodFailure:
         """
         LOGGER.info("Started: Test to verify degraded READs after each pod failure till K "
                     "server pods down - unsafe shutdown.")
-
-        LOGGER.info("STEP 1: Perform WRITEs with variable object sizes.")
+        LOGGER.info("STEP 1: Perform WRITEs/READs and Verify DI with variable object sizes.")
         users = self.mgnt_ops.create_account_users(nusers=1)
         self.test_prefix = 'test-40568'
         self.s3_clean = users
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                    log_prefix=self.test_prefix, skipread=True,
+                                                    log_prefix=self.test_prefix,
                                                     skipcleanup=True, nsamples=2, nclients=2)
         assert_utils.assert_true(resp[0], resp[1])
-        LOGGER.info("Step 1: Performed WRITEs with variable sizes objects.")
-
-        LOGGER.info("Step 2: Perform READs and verify DI on the written data")
-        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                    log_prefix=self.test_prefix, skipwrite=True,
-                                                    skipcleanup=True, nsamples=2, nclients=2)
-        assert_utils.assert_true(resp[0], resp[1])
-        LOGGER.info("Step 2: Performed READs and verified DI on the written data")
-
-        LOGGER.info("Shutdown %s (K) server pods one by one and verify read/verify "
-                    "after each pod down", self.kvalue)
-        LOGGER.info("Get server pod names to be deleted")
-        pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
-        LOGGER.info("Get data pod names")
-        data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
-        LOGGER.info("Combine data and server pods names")
-        server_data_pod_list = pod_list + data_pod_list
-        for count, pod_name in enumerate(self.pod_name_list):
-            count += 1
-            LOGGER.info("Step 3: Shutdown %s server pod %s by deleting deployment (unsafe)",
-                        count, pod_name)
+        LOGGER.info("Step 1: Perform WRITEs/READs and Verify DI with variable object sizes.")
+        LOGGER.info("Step 2: Shutdown %s (K) server pods one by one, verify cluster, remaining"
+                    " pods status and verify read/verify after each pod down", self.kvalue)
+        for count in range(1, self.kvalue+1):
+            resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+                master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+                pod_prefix=[const.SERVER_POD_NAME_PREFIX],
+                down_method=const.RESTORE_DEPLOYMENT_K8S)
+            assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+            pod_name = list(resp[1].keys())[0]
             pod_data = list()
-            pod_data.append(
-                self.node_master_list[0].get_pod_hostname(pod_name=pod_name))  # hostname
-            resp = self.node_master_list[0].delete_deployment(pod_name=pod_name)
-            LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_false(resp[0], f"Failed to delete {count} server pod {pod_name} "
-                                               "by deleting deployment (unsafe)")
-            pod_data.append(resp[1])  # deployment_backup
-            pod_data.append(resp[2])  # deployment_name
-            self.restore_pod = self.deploy = True
-            self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+            pod_data.append(resp[1][pod_name]['hostname'])  # hostname
+            pod_data.append(resp[1][pod_name]['deployment_backup'])
+            pod_data.append(resp[1][pod_name]['deployment_name'])
+            self.pod_name_list.append(pod_name)
             self.pod_dict[pod_name] = pod_data
-            LOGGER.info("Step 3: Deleted %s server pod %s by deleting deployment (unsafe)",
-                        count, pod_name)
-
-            LOGGER.info("Step 4: Check cluster status")
-            resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
-            assert_utils.assert_false(resp[0], resp)
-            LOGGER.info("Step 4: Cluster has some failures due to %s server pods has gone down.",
-                        count)
-
-            LOGGER.info("Step 5: Check services status that were running on server pod %s which "
-                        "are deleted", pod_name)
-            hostname = self.pod_dict.get(pod_name)[0]
-            resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=[pod_name], fail=True,
-                                                               hostname=hostname)
-            assert_utils.assert_true(resp[0], resp[1])
-            server_data_pod_list.remove(pod_name)
-            LOGGER.info("Step 5: Services of deleted server pod %s are in offline state", pod_name)
-
-            LOGGER.info("Step 6: Check services status on remaining pods %s", server_data_pod_list)
-            resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=server_data_pod_list,
-                                                               fail=False)
-            LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_true(resp[0], resp)
-            LOGGER.info("Step 6: Services of remaining pods are in online state")
-
-            LOGGER.info("Step 7: Perform READs and verify DI on the written data")
+            self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+            self.restore_pod = True
+            assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+            LOGGER.info("Deleted %s server pod %s by deleting deployment (unsafe)", count,
+                        pod_name)
+            LOGGER.info("Step 3: Perform READs and verify DI on the written data")
             resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                         log_prefix=self.test_prefix,
                                                         skipwrite=True, skipcleanup=True,
-                                                        nsamples=2, nclients=2)
+                                                        nsamples=2, nclients=2,
+                                                        setup_s3bench=False)
             assert_utils.assert_true(resp[0], resp[1])
-            LOGGER.info("Step 7: Performed READs and verified DI on the written data")
-
-        LOGGER.info("%s (K) server pods shutdown one by one successfully and read/verify "
-                    "after each pod down verified", self.kvalue)
-
+            LOGGER.info("Step 3: Performed READs and verified DI on the written data")
+        LOGGER.info("Step 2: %s (K) server pods shutdown one by one successfully, Verified "
+                    "cluster, services states are as expected & remaining pods status is online"
+                    " and read/verify after each pod down verified", self.kvalue)
         LOGGER.info("Completed: Test to verify degraded READs after each pod failure till K "
                     "server pods down - unsafe shutdown.")
 
@@ -397,10 +285,9 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40573")
-    @CTFailOn(error_handler)
-    def test_deletes_kserver_pods_down(self):
+    def test_deletes_kserver_pods_fail(self):
         """
-        This test tests DELETEs after all K server pods down - unsafe shutdown
+        This test tests Degraded DELETEs after all K server pods down - unsafe shutdown
         """
         LOGGER.info("STARTED: Test to verify DELETEs after %s (K) server pods down - "
                     "unsafe shutdown", self.kvalue)
@@ -423,11 +310,9 @@ class TestMultiServerPodFailure:
         s3_test_obj = S3TestLib(access_key=access_key, secret_key=secret_key,
                                 endpoint_url=S3_CFG["s3_url"])
         LOGGER.info("Successfully created IAM user with name %s", self.s3acc_name)
-
         LOGGER.info("Create %s buckets and put variable size objects.", wr_bucket)
         args = {'test_prefix': self.test_prefix, 'test_dir_path': self.test_dir_path,
                 'skipget': True, 'skipdel': True, 'bkts_to_wr': wr_bucket, 'output': wr_output}
-
         self.ha_obj.put_get_delete(event, s3_test_obj, **args)
         wr_resp = tuple()
         while len(wr_resp) != 3:
@@ -439,68 +324,29 @@ class TestMultiServerPodFailure:
                                                            "number of buckets")
         LOGGER.info("Step 1: Successfully created %s buckets & "
                     "perform WRITEs with variable size objects.", wr_bucket)
-
-        LOGGER.info("Step 2: Shutdown %s (K) server pods one by one by deleting deployment ("
-                    "unsafe)", self.kvalue)
-        LOGGER.info("Get server pod names to be deleted")
-        pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
-        LOGGER.info("Get data pod names")
-        data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
-        LOGGER.info("Combine data and server pods names")
-        server_data_pod_list = pod_list + data_pod_list
-        for count, pod_name in enumerate(self.pod_name_list):
-            count += 1
-            LOGGER.info("Shutdown %s server pod %s by deleting deployment "
-                        "(unsafe)", count, pod_name)
+        LOGGER.info("Step 2: Shutdown random %s (K) server pods by deleting deployment ("
+                    "unsafe) and verify cluster & remaining pods status", self.kvalue)
+        resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+            master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+            pod_prefix=[const.SERVER_POD_NAME_PREFIX], down_method=const.RESTORE_DEPLOYMENT_K8S,
+            kvalue=self.kvalue)
+        assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+        for pod_name in resp[1].keys():
             pod_data = list()
-            pod_data.append(
-                self.node_master_list[0].get_pod_hostname(pod_name=pod_name))  # hostname
-            resp = self.node_master_list[0].delete_deployment(pod_name=pod_name)
-            LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_false(resp[0], f"Failed to delete {count} server pod {pod_name} "
-                                               "by deleting deployment (unsafe)")
-            pod_data.append(resp[1])  # deployment_backup
-            pod_data.append(resp[2])  # deployment_name
-            self.restore_pod = self.deploy = True
-            self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+            pod_data.append(resp[1][pod_name]['hostname'])  # hostname
+            pod_data.append(resp[1][pod_name]['deployment_backup'])
+            pod_data.append(resp[1][pod_name]['deployment_name'])
+            self.pod_name_list.append(pod_name)
             self.pod_dict[pod_name] = pod_data
-            LOGGER.info("Deleted %s server pod %s by deleting deployment "
-                        "(unsafe)", count, pod_name)
-        LOGGER.info("Step 2: Successfully shutdown %s (K) server pods one by one by deleting "
-                    "deployment (unsafe)", self.kvalue)
-
-        LOGGER.info("Step 3: Check cluster status")
-        resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
-        assert_utils.assert_false(resp[0], resp)
-        LOGGER.info("Step 3: Cluster has some failures due to %s server pods has gone down.",
-                    self.kvalue)
-
-        LOGGER.info("Step 4: Check services status that were running on server pods "
-                    "which are deleted.")
-        counter = 0
-        for pod_name in self.pod_name_list:
-            hostname = self.pod_dict.get(pod_name)[0]
-            resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=[pod_name], fail=True,
-                                                               hostname=hostname)
-            LOGGER.debug("Services status on %s : %s", pod_name, resp)
-            if not resp[0]:
-                counter += 1
-            server_data_pod_list.remove(pod_name)
-        assert_utils.assert_equal(counter, 0, "Services on some server pods not stopped.")
-        LOGGER.info("Step 4: Services of deleted server pods are in offline state")
-
-        LOGGER.info("Step 5: Check services status on remaining pods %s", server_data_pod_list)
-        resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=server_data_pod_list,
-                                                           fail=False)
-        LOGGER.debug("Response: %s", resp)
-        assert_utils.assert_true(resp[0], resp)
-        LOGGER.info("Step 5: Services of remaining pods are in online state")
-
-        LOGGER.info("Step 6: Perform DELETEs on random %s buckets", del_bucket)
+        self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("Step 2: Successfully shutdown random %s (K) server pod %s. Verified cluster"
+                    " and services states are as expected & remaining pods status is online.",
+                    self.kvalue, self.pod_name_list)
+        LOGGER.info("Step 3: Perform DELETEs on random %s buckets", del_bucket)
         args = {'test_prefix': self.test_prefix, 'test_dir_path': self.test_dir_path,
                 'skipput': True, 'skipget': True, 'bkts_to_del': del_bucket, 'output': del_output}
-
         self.ha_obj.put_get_delete(event, s3_test_obj, **args)
         del_resp = tuple()
         while len(del_resp) != 2:
@@ -509,9 +355,8 @@ class TestMultiServerPodFailure:
         assert_utils.assert_equal(len(remain_bkt), wr_bucket - del_bucket,
                                   f"Failed to delete {del_bucket} number of buckets from "
                                   f"{wr_bucket}. Remaining {len(remain_bkt)} number of buckets")
-        LOGGER.info("Step 6: Successfully performed DELETEs on random %s buckets", del_bucket)
-
-        LOGGER.info("Step 7: Perform READs and verify DI on the remaining %s "
+        LOGGER.info("Step 3: Successfully performed DELETEs on random %s buckets", del_bucket)
+        LOGGER.info("Step 4: Perform READs and verify DI on the remaining %s "
                     "buckets.", remain_bkt)
         rd_output = Queue()
         new_s3data = dict()
@@ -528,16 +373,14 @@ class TestMultiServerPodFailure:
         fail_bkt_get = rd_resp[1]
         event_di_bkt = rd_resp[2]
         fail_di_bkt = rd_resp[3]
-
         # Above four lists are expected to be empty as all pass expected
         assert_utils.assert_false(len(fail_bkt_get) or len(fail_di_bkt) or len(event_bkt_get) or
                                   len(event_di_bkt), "Expected pass in read and di check "
                                                      "operations. Found failures in READ: "
                                                      f"{fail_bkt_get} {event_bkt_get}"
                                                      f"or DI_CHECK: {fail_di_bkt} {event_di_bkt}")
-        LOGGER.info("Step 7: Successfully performed READs and verify DI on the remaining "
+        LOGGER.info("Step 4: Successfully performed READs and verify DI on the remaining "
                     "%s buckets.", remain_bkt)
-
         LOGGER.info("ENDED: Test to verify DELETEs after %s (K) server pods down"
                     " - unsafe shutdown.", self.kvalue)
 
@@ -545,7 +388,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40578")
-    @CTFailOn(error_handler)
     def test_writes_till_kserver_pods_fail(self):
         """
         Test to verify degraded WRITEs after each pod failure till K server pods
@@ -553,7 +395,6 @@ class TestMultiServerPodFailure:
         """
         LOGGER.info("Started: Test to verify degraded Writes after each pod failure till K "
                     "server pods down - unsafe shutdown.")
-
         LOGGER.info("STEP 1: Perform WRITEs-READs-Verify with variable object sizes.")
         users = self.mgnt_ops.create_account_users(nusers=1)
         self.test_prefix = 'test-40578'
@@ -563,79 +404,50 @@ class TestMultiServerPodFailure:
                                                     skipcleanup=True, nsamples=2, nclients=2)
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 1: Performed WRITEs-READs-Verify with variable sizes objects.")
-
-        LOGGER.info("Shutdown %s (K) server pods one by one and verify WRITEs  "
-                    "after each server pod down on new and existing buckets", self.kvalue)
-        LOGGER.info("Get server pod names to be deleted")
-        pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
-        LOGGER.info("Get data pod names")
-        data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
-        LOGGER.info("Combine data and server pods names")
-        server_data_pod_list = pod_list + data_pod_list
-        for count, pod_name in enumerate(self.pod_name_list):
-            count += 1
-            LOGGER.info("Step 2: Shutdown %s server pod %s by deleting deployment (unsafe)",
-                        count, pod_name)
+        LOGGER.info("Step 2: Shutdown %s (K) server pods one by one, verify cluster, remaining "
+                    "pods status and verify WRITES after each server pod down on new and "
+                    "existing buckets", self.kvalue)
+        for count in range(1, self.kvalue+1):
+            resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+                master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+                pod_prefix=[const.SERVER_POD_NAME_PREFIX],
+                down_method=const.RESTORE_DEPLOYMENT_K8S)
+            assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+            pod_name = list(resp[1].keys())[0]
             pod_data = list()
-            resp = self.node_master_list[0].delete_deployment(pod_name=pod_name)
-            LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_false(resp[0], f"Failed to delete {count} server pod {pod_name}"
-                                               "by deleting deployment (unsafe)")
-            pod_data.append(resp[1])  # deployment_backup
-            pod_data.append(resp[2])  # deployment_name
-            self.restore_pod = self.deploy = True
-            self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+            pod_data.append(resp[1][pod_name]['hostname'])  # hostname
+            pod_data.append(resp[1][pod_name]['deployment_backup'])
+            pod_data.append(resp[1][pod_name]['deployment_name'])
+            self.pod_name_list.append(pod_name)
             self.pod_dict[pod_name] = pod_data
-            LOGGER.info("Step 2: Deleted %s server pod %s by deleting deployment (unsafe)",
-                        count, pod_name)
-
-            LOGGER.info("Step 3: Check cluster status")
-            resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
-            assert_utils.assert_false(resp[0], resp)
-            LOGGER.info("Step 3: Cluster has some failures due to %s server pods has gone down.",
-                        count)
-
-            LOGGER.info("Step 4: Check services status that were running on server pod %s which "
-                        "are deleted", pod_name)
-            hostname = self.pod_dict.get(pod_name)[0]
-            resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=[pod_name], fail=True,
-                                                               hostname=hostname)
-            assert_utils.assert_true(resp[0], resp[1])
-            server_data_pod_list.remove(pod_name)
-            LOGGER.info("Step 4: Services of deleted server pod %s are in offline state", pod_name)
-
-            LOGGER.info("Step 5: Check services status on remaining pods %s", server_data_pod_list)
-            resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=server_data_pod_list,
-                                                               fail=False)
-            LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_true(resp[0], resp)
-            LOGGER.info("Step 5: Services of remaining pods are in online state")
-
-            LOGGER.info("Step 6: Perform WRITEs, READs and verify DI on the already created "
+            self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+            self.restore_pod = True
+            assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+            LOGGER.info("Deleted %s server pod %s by deleting deployment (unsafe)", count,
+                        pod_name)
+            LOGGER.info("Step 3: Perform WRITEs, READs and verify DI on the already created "
                         "bucket")
             resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                         log_prefix=self.test_prefix,
-                                                        skipcleanup=True, nsamples=2, nclients=2)
+                                                        skipcleanup=True, nsamples=2, nclients=2,
+                                                        setup_s3bench=False)
             assert_utils.assert_true(resp[0], resp[1])
-            LOGGER.info("Step 6: Successfully performed WRITEs, READs and verify DI on "
+            LOGGER.info("Step 3: Successfully performed WRITEs, READs and verify DI on "
                         "already created bucket")
-
-            LOGGER.info("Step 7: Perform WRITEs-READs-Verify with variable object sizes.")
+            LOGGER.info("Step 4: Perform WRITEs-READs-Verify with variable object sizes.")
             users_new = self.mgnt_ops.create_account_users(nusers=1)
             test_prefix_new = f'test-40578-{count}'
             self.s3_clean.update(users_new)
             resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users_new.values())[0],
                                                         log_prefix=test_prefix_new,
                                                         skipcleanup=True,
-                                                        nsamples=2, nclients=2)
+                                                        nsamples=2, nclients=2,
+                                                        setup_s3bench=False)
             assert_utils.assert_true(resp[0], resp[1])
-            LOGGER.info("Step 7: Performed WRITEs-READs-Verify with variable sizes objects.")
-
-        LOGGER.info("%s (K) server pods shutdown one by one successfully and WRITEs "
-                    "after each server pod down on new and existing buckets "
-                    "verified", self.kvalue)
-
+            LOGGER.info("Step 4: Performed WRITEs-READs-Verify with variable sizes objects.")
+        LOGGER.info("Step 2: %s (K) server pods shutdown one by one successfully, Verify cluster,"
+                    "services states are as expected & remaining pods status is online and WRITEs "
+                    "after each server pod down on new and existing buckets verified", self.kvalue)
         LOGGER.info("Completed: Test to verify degraded WRITEs after each pod failure till K "
                     "server pods down - unsafe shutdown.")
 
@@ -643,14 +455,12 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40579")
-    @CTFailOn(error_handler)
     def test_writes_kserver_pods_failure(self):
         """
         Test to verify degraded WRITEs after all K server pods down - unsafe shutdown.
         """
         LOGGER.info("Started: Test to verify degraded WRITEs after all K server pods "
                     "down - unsafe shutdown.")
-
         LOGGER.info("STEP 1: Perform WRITEs-READs-Verify with variable object sizes.")
         users = self.mgnt_ops.create_account_users(nusers=1)
         self.test_prefix = 'test-40579'
@@ -660,78 +470,43 @@ class TestMultiServerPodFailure:
                                                     skipcleanup=True, nsamples=2, nclients=2)
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 1: Performed WRITEs-READs-Verify with variable sizes objects.")
-
-        LOGGER.info("Step 2: Shutdown the server pod by deleting deployment (unsafe)")
-        LOGGER.info("Get server pod names to be deleted")
-        pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
-        LOGGER.info("Get data pod names")
-        data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
-        LOGGER.info("Combine data and server pods names")
-        server_data_pod_list = pod_list + data_pod_list
-        for count, pod_name in enumerate(self.pod_name_list):
-            count += 1
+        LOGGER.info("Step 2: Shutdown random %s (K) server by deleting deployment and verify "
+                    "cluster & remaining pods status", self.kvalue)
+        resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+            master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+            pod_prefix=[const.SERVER_POD_NAME_PREFIX], down_method=const.RESTORE_DEPLOYMENT_K8S,
+            kvalue=self.kvalue)
+        assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+        for pod_name in resp[1].keys():
             pod_data = list()
-            pod_data.append(
-                self.node_master_list[0].get_pod_hostname(pod_name=pod_name))  # hostname
-            LOGGER.info("Deleting %s server pod %s", count, pod_name)
-            resp = self.node_master_list[0].delete_deployment(pod_name=pod_name)
-            LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_false(resp[0], f"Failed to delete {count} server pod {pod_name}"
-                                               " by deleting deployment (unsafe)")
-            pod_data.append(resp[1])  # deployment_backup
-            pod_data.append(resp[2])  # deployment_name
-            self.restore_pod = self.deploy = True
-            self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+            pod_data.append(resp[1][pod_name]['hostname'])  # hostname
+            pod_data.append(resp[1][pod_name]['deployment_backup'])
+            pod_data.append(resp[1][pod_name]['deployment_name'])
+            self.pod_name_list.append(pod_name)
             self.pod_dict[pod_name] = pod_data
-            LOGGER.info("Deleted %s server pod %s by deleting deployment "
-                        "(unsafe)", count, pod_name)
-        LOGGER.info("Step 2: Successfully deleted %s server pods", self.kvalue)
-
-        LOGGER.info("Step 3: Check cluster status")
-        resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
-        assert_utils.assert_false(resp[0], resp)
-        LOGGER.info("Step 3: Cluster has some failures due to %s server pods has gone down.",
-                    self.kvalue)
-
-        LOGGER.info("Step 4: Check services status that were running on server pods "
-                    "which are deleted.")
-        counter = 0
-        for pod_name in self.pod_name_list:
-            hostname = self.pod_dict.get(pod_name)[0]
-            resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=[pod_name], fail=True,
-                                                               hostname=hostname)
-            LOGGER.debug("Services status on %s : %s", pod_name, resp)
-            if not resp[0]:
-                counter += 1
-            server_data_pod_list.remove(pod_name)
-        assert_utils.assert_equal(counter, 0, "Services on some server pods not stopped.")
-        LOGGER.info("Step 4: Services of server pods are in offline state")
-
-        LOGGER.info("Step 5: Check services status on remaining pods %s", server_data_pod_list)
-        resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=server_data_pod_list,
-                                                           fail=False)
-        LOGGER.debug("Response: %s", resp)
-        assert_utils.assert_true(resp[0], resp)
-        LOGGER.info("Step 5: Services of remaining pods are in online state")
-
-        LOGGER.info("Step 6: Perform WRITEs-READs-Verify and verify DI on the written data")
+        self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("Step 2: Successfully shutdown random %s (K) server pod %s by deleting "
+                    "deployment. Verified cluster and services states are as expected & remaining"
+                    " pods status is online.", self.kvalue, self.pod_name_list)
+        LOGGER.info("Step 3: Perform WRITEs-READs-Verify and verify DI on the written data")
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                     log_prefix=self.test_prefix,
-                                                    skipcleanup=True, nsamples=2, nclients=2)
+                                                    skipcleanup=True, nsamples=2, nclients=2,
+                                                    setup_s3bench=False)
         assert_utils.assert_true(resp[0], resp[1])
-        LOGGER.info("Step 6: Performed WRITEs-READs-Verify and verified DI on the written data")
-
-        LOGGER.info("Step 7: Perform WRITEs-READs-Verify with variable object sizes.")
+        LOGGER.info("Step 3: Performed WRITEs-READs-Verify and verified DI on the written data")
+        LOGGER.info("Step 4: Perform WRITEs-READs-Verify with variable object sizes.")
         users = self.mgnt_ops.create_account_users(nusers=1)
         self.test_prefix = 'test-40579-1'
         self.s3_clean.update(users)
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                     log_prefix=self.test_prefix,
-                                                    skipcleanup=True, nsamples=2, nclients=2)
+                                                    skipcleanup=True, nsamples=2, nclients=2,
+                                                    setup_s3bench=False)
         assert_utils.assert_true(resp[0], resp[1])
-        LOGGER.info("Step 7: Performed WRITEs-READs-Verify with variable sizes objects ")
-
+        LOGGER.info("Step 4: Performed WRITEs-READs-Verify with variable sizes objects ")
         LOGGER.info("Completed: Test to verify degraded WRITEs after all K server pods "
                     "down - unsafe shutdown.")
 
@@ -739,7 +514,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40580")
-    @CTFailOn(error_handler)
     def test_deletes_till_kserver_pods_fail(self):
         """
         Test to verify degraded DELETEs after each pod failure till K server pods
@@ -771,7 +545,6 @@ class TestMultiServerPodFailure:
         LOGGER.info("Create %s buckets and put variable size objects.", wr_bucket)
         args = {'test_prefix': self.test_prefix, 'test_dir_path': self.test_dir_path,
                 'skipget': True, 'skipdel': True, 'bkts_to_wr': wr_bucket, 'output': wr_output}
-
         self.ha_obj.put_get_delete(event, s3_test_obj, **args)
         wr_resp = tuple()
         while len(wr_resp) != 3:
@@ -783,64 +556,31 @@ class TestMultiServerPodFailure:
                                                            "number of buckets")
         LOGGER.info("Step 1: Successfully created %s buckets & "
                     "perform WRITEs with variable size objects.", wr_bucket)
-
-        LOGGER.info("Shutdown %s (K) server pods one by one and perform Delete on random %s"
-                    " buckets and verify read on remaining bucket after each server pod down",
-                    self.kvalue, del_bucket)
-        LOGGER.info("Get server pod names to be deleted")
-        pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
-        LOGGER.info("Get data pod names")
-        data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
-        LOGGER.info("Combine data and server pods names")
-        server_data_pod_list = pod_list + data_pod_list
-        for count, pod_name in enumerate(self.pod_name_list):
-            count += 1
-            LOGGER.info("Step 2: Shutdown %s server pod %s by deleting deployment (unsafe)",
-                        count, pod_name)
+        LOGGER.info("Step 2: Shutdown %s (K) server pods one by one, verify cluster, remaining "
+                    "pods status and perform Delete on random %s buckets and verify read on "
+                    "remaining bucket after each server pod down", self.kvalue, del_bucket)
+        for count in range(1, self.kvalue+1):
+            resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+                master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+                pod_prefix=[const.SERVER_POD_NAME_PREFIX],
+                down_method=const.RESTORE_DEPLOYMENT_K8S)
+            assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+            pod_name = list(resp[1].keys())[0]
             pod_data = list()
-            pod_data.append(
-                self.node_master_list[0].get_pod_hostname(pod_name=pod_name))  # hostname
-            resp = self.node_master_list[0].delete_deployment(pod_name=pod_name)
-            LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_false(resp[0], f"Failed to delete {count} server pod {pod_name} "
-                                               f"by deleting deployment (unsafe)")
-            pod_data.append(resp[1])  # deployment_backup
-            pod_data.append(resp[2])  # deployment_name
-            self.restore_pod = self.deploy = True
-            self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+            pod_data.append(resp[1][pod_name]['hostname'])  # hostname
+            pod_data.append(resp[1][pod_name]['deployment_backup'])
+            pod_data.append(resp[1][pod_name]['deployment_name'])
+            self.pod_name_list.append(pod_name)
             self.pod_dict[pod_name] = pod_data
-            LOGGER.info("Step 2: Deleted %s server pod %s by deleting deployment (unsafe)",
-                        count, pod_name)
-
-            LOGGER.info("Step 3: Check cluster status")
-            resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
-            assert_utils.assert_false(resp[0], resp)
-            LOGGER.info("Step 3: Cluster has some failures due to server pod %s has "
-                        "gone down.", pod_name)
-
-            LOGGER.info("Step 4: Check services status that were running "
-                        "on server pod %s which is deleted", pod_name)
-            hostname = self.pod_dict.get(pod_name)[0]
-            resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=[pod_name], fail=True,
-                                                               hostname=hostname)
-            assert_utils.assert_true(resp[0], resp[1])
-            server_data_pod_list.remove(pod_name)
-            LOGGER.info("Step 4: Services of server pod %s are in offline state", pod_name)
-
-            LOGGER.info("Step 5: Check services status on remaining "
-                        "pods %s", server_data_pod_list)
-            resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=server_data_pod_list,
-                                                               fail=False)
-            LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_true(resp[0], resp)
-            LOGGER.info("Step 5: Services of remaining pods are in online state")
-
-            LOGGER.info("Step 6: Perform DELETEs on random %s buckets", del_bucket)
+            self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+            self.restore_pod = True
+            assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+            LOGGER.info("Deleted %s server pod %s by deleting deployment (unsafe)", count,
+                        pod_name)
+            LOGGER.info("Step 3: Perform DELETEs on random %s buckets", del_bucket)
             args = {'test_prefix': self.test_prefix, 'test_dir_path': self.test_dir_path,
                     'skipput': True, 'skipget': True, 'bkts_to_del': del_bucket,
                     'output': del_output}
-
             self.ha_obj.put_get_delete(event, s3_test_obj, **args)
             del_resp = tuple()
             while len(del_resp) != 2:
@@ -850,16 +590,14 @@ class TestMultiServerPodFailure:
                                       f"Failed to delete {del_bucket} number of buckets from "
                                       f"{wr_bucket}. Remaining {len(remain_bkt)} number of "
                                       "buckets")
-            LOGGER.info("Step 6: Successfully performed DELETEs on random %s buckets", del_bucket)
+            LOGGER.info("Step 3: Successfully performed DELETEs on random %s buckets", del_bucket)
             wr_bucket = len(remain_bkt)
-
-            LOGGER.info("Step 7: Perform READs and verify DI on the remaining %s "
+            LOGGER.info("Step 4: Perform READs and verify DI on the remaining %s "
                         "buckets", remain_bkt)
             rd_output = Queue()
             new_s3data = dict()
             for bkt in remain_bkt:
                 new_s3data[bkt] = s3_data[bkt]
-
             args = {'test_prefix': self.test_prefix, 'test_dir_path': self.test_dir_path,
                     'skipput': True, 'skipdel': True, 's3_data': new_s3data, 'di_check': True,
                     'output': rd_output}
@@ -871,7 +609,6 @@ class TestMultiServerPodFailure:
             fail_bkt_get = rd_resp[1]
             event_di_bkt = rd_resp[2]
             fail_di_bkt = rd_resp[3]
-
             # Above four lists are expected to be empty as all pass expected
             assert_utils.assert_false(len(fail_bkt_get) or len(fail_di_bkt) or len(event_bkt_get)
                                       or len(event_di_bkt), "Expected pass in read and di check "
@@ -879,13 +616,12 @@ class TestMultiServerPodFailure:
                                                             f"{fail_bkt_get} {event_bkt_get}"
                                                             f"or DI_CHECK: {fail_di_bkt} "
                                                             f"{event_di_bkt}")
-            LOGGER.info("Step 7: Successfully performed READs and verify DI on the remaining"
+            LOGGER.info("Step 4: Successfully performed READs and verify DI on the remaining"
                         " %s buckets.", remain_bkt)
-
-        LOGGER.info("Shutdown %s (K) server pods one by one and performed Deletes "
-                    "on random buckets and verified read on remaining bucket after"
-                    " each server pod down", self.kvalue)
-
+        LOGGER.info("Step 2: %s (K) server pods shutdown one by one successfully, Verify cluster,"
+                    " services states are as expected & remaining pods status is online and "
+                    "performed Deletes on random buckets and verified read on remaining bucket "
+                    "after each server pod down", self.kvalue)
         LOGGER.info("Completed: Test to verify degraded DELETEs after each pod failure till K "
                     "server pods down - unsafe shutdown.")
 
@@ -893,14 +629,12 @@ class TestMultiServerPodFailure:
     @pytest.mark.lc
     @pytest.mark.skip(reason="Not supported in RGW yet")
     @pytest.mark.tags("TEST-40581")
-    @CTFailOn(error_handler)
     def test_copy_object_kserver_pods_fail(self):
         """
         Test to Verify copy object when all K server pods are down - unsafe shutdown.
         """
         LOGGER.info("STARTED: Test to Verify copy object when all K server pods "
                     "down - unsafe shutdown.")
-
         bkt_cnt = HA_CFG["copy_obj_data"]["bkt_cnt"]
         bkt_obj_dict = dict()
         for cnt in range(bkt_cnt):
@@ -931,76 +665,40 @@ class TestMultiServerPodFailure:
         put_etag = resp[1]
         LOGGER.info("Step 1: successfully created and listed buckets and performed upload and copy"
                     "object from %s bucket to other buckets", self.bucket_name)
-
-        LOGGER.info("Step 2: Shutdown the %s (K) server pods by deleting deployment "
-                    "(unsafe)", self.kvalue)
-        LOGGER.info("Get server pod names to be deleted")
-        pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
-        LOGGER.info("Get data pod names")
-        data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
-        LOGGER.info("Combine data and server pods names")
-        server_data_pod_list = pod_list + data_pod_list
-        for count, pod_name in enumerate(self.pod_name_list):
-            count += 1
+        LOGGER.info("Step 2: Shutdown random %s (K) server pods by deleting deployment (unsafe)"
+                    " and verify cluster & remaining pods status", self.kvalue)
+        resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+            master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+            pod_prefix=[const.SERVER_POD_NAME_PREFIX], down_method=const.RESTORE_DEPLOYMENT_K8S,
+            kvalue=self.kvalue)
+        assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+        for pod_name in resp[1].keys():
             pod_data = list()
-            pod_data.append(
-                self.node_master_list[0].get_pod_hostname(pod_name=pod_name))  # hostname
-            LOGGER.info("Deleting %s server pod %s", count, pod_name)
-            resp = self.node_master_list[0].delete_deployment(pod_name=pod_name)
-            LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_false(resp[0], f"Failed to delete {count} server pod {pod_name}"
-                                               " by deleting deployment (unsafe)")
-            pod_data.append(resp[1])  # deployment_backup
-            pod_data.append(resp[2])  # deployment_name
-            self.restore_pod = self.deploy = True
-            self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+            pod_data.append(resp[1][pod_name]['hostname'])  # hostname
+            pod_data.append(resp[1][pod_name]['deployment_backup'])
+            pod_data.append(resp[1][pod_name]['deployment_name'])
+            self.pod_name_list.append(pod_name)
             self.pod_dict[pod_name] = pod_data
-            LOGGER.info("Deleted %s server pod %s by deleting deployment "
-                        "(unsafe)", count, pod_name)
-        LOGGER.info("Step 2: Successfully deleted %s server pods", self.kvalue)
-
-        LOGGER.info("Step 3: Check cluster status")
-        resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
-        assert_utils.assert_false(resp[0], resp)
-        LOGGER.info("Step 3: Cluster has some failures due to %s server pods has gone down.",
-                    self.kvalue)
-
-        LOGGER.info("Step 4: Check services status that were running on server pods"
-                    " which are deleted.")
-        counter = 0
-        for pod_name in self.pod_name_list:
-            hostname = self.pod_dict.get(pod_name)[0]
-            resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=[pod_name], fail=True,
-                                                               hostname=hostname)
-            LOGGER.debug("Services status on %s : %s", pod_name, resp)
-            if not resp[0]:
-                counter += 1
-            server_data_pod_list.remove(pod_name)
-        assert_utils.assert_equal(counter, 0, "Services on some server pods not stopped.")
-        LOGGER.info("Step 4: Services of server pods are in offline state")
-
-        LOGGER.info("Step 5: Check services status on remaining pods %s", server_data_pod_list)
-        resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=server_data_pod_list,
-                                                           fail=False)
-        LOGGER.debug("Response: %s", resp)
-        assert_utils.assert_true(resp[0], resp)
-        LOGGER.info("Step 5: Services of remaining pods are in online state")
-
-        LOGGER.info("Step 6: Download the uploaded objects & verify etags")
+        self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("Step 2: Successfully shutdown random %s (K) server pod %s. Verified cluster "
+                    "and services states are as expected & remaining pods status is online.",
+                    self.kvalue, self.pod_name_list)
+        LOGGER.info("Step 3: Download the uploaded objects & verify etags")
         for key, val in bkt_obj_dict.items():
             resp = s3_test_obj.get_object(bucket=key, key=val)
             LOGGER.info("Get object response: %s", resp)
             get_etag = resp[1]["ETag"]
             assert_utils.assert_equal(put_etag, get_etag, "Failed to match GET-PUT ETAG for "
                                                           f"object {key} of bucket {val}.")
-        LOGGER.info("Step 6: Successfully download the uploaded objects & verify etags")
+        LOGGER.info("Step 3: Successfully download the uploaded objects & verify etags")
 
         bucket3 = f"ha-bkt3-{int((perf_counter_ns()))}"
         object3 = f"ha-obj3-{int((perf_counter_ns()))}"
         bkt_obj_dict.clear()
         bkt_obj_dict[bucket3] = object3
-        LOGGER.info("Step 7: Perform copy of %s from already created/uploaded %s to %s and verify "
+        LOGGER.info("Step 4: Perform copy of %s from already created/uploaded %s to %s and verify "
                     "copy object etags", self.object_name, self.bucket_name, bucket3)
         resp = self.ha_obj.create_bucket_copy_obj(event, s3_test_obj=s3_test_obj,
                                                   bucket_name=self.bucket_name,
@@ -1009,25 +707,21 @@ class TestMultiServerPodFailure:
                                                   put_etag=put_etag,
                                                   bkt_op=False)
         assert_utils.assert_true(resp[0], f"Failed buckets are: {resp[1]}")
-        LOGGER.info("Step 7: Performed copy of %s from already created/uploaded %s to %s and "
+        LOGGER.info("Step 4: Performed copy of %s from already created/uploaded %s to %s and "
                     "verified copy object etags", self.object_name, self.bucket_name, bucket3)
-
-        LOGGER.info("Step 8: Download the uploaded %s on %s & verify etags.", object3, bucket3)
+        LOGGER.info("Step 5: Download the uploaded %s on %s & verify etags.", object3, bucket3)
         resp = s3_test_obj.get_object(bucket=bucket3, key=object3)
         LOGGER.info("Get object response: %s", resp)
         get_etag = resp[1]["ETag"]
         assert_utils.assert_equal(put_etag, get_etag, "Failed in verification of Put & Get Etag "
                                                       f"for object {object3} of bucket {bucket3}.")
-        LOGGER.info("Step 8: Downloaded the uploaded %s on %s & verified etags.", object3, bucket3)
-
+        LOGGER.info("Step 5: Downloaded the uploaded %s on %s & verified etags.", object3, bucket3)
         LOGGER.info("COMPLETED: Test to Verify copy object when all K server pods "
                     "down - unsafe shutdown.")
 
     @pytest.mark.ha
     @pytest.mark.lc
-    @pytest.mark.skip(reason="Multipart feature F-20C targeted for PI-7")
     @pytest.mark.tags("TEST-40582")
-    @CTFailOn(error_handler)
     def test_mpu_after_kserver_pods_fail(self):
         """
         This test tests multipart upload after all K server pods down - unsafe shutdown
@@ -1038,7 +732,6 @@ class TestMultiServerPodFailure:
         total_parts = HA_CFG["5gb_mpu_data"]["total_parts"]
         download_file = self.test_file + "_download"
         download_path = os.path.join(self.test_dir_path, download_file)
-
         LOGGER.info("Step 1: Create bucket and perform multipart upload of size %sMB.",
                     file_size)
         LOGGER.info("Creating IAM user with name %s", self.s3acc_name)
@@ -1067,63 +760,27 @@ class TestMultiServerPodFailure:
         upload_checksum = str(resp[2])
         LOGGER.info("Step 1: Successfully performed multipart upload for size %sMB.",
                     file_size)
-
-        LOGGER.info("Step 2: Shutdown the %s (K) server pods by deleting deployment (unsafe)",
-                    self.kvalue)
-        LOGGER.info("Get server pod names to be deleted")
-        pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
-        LOGGER.info("Get data pod names")
-        data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
-        LOGGER.info("Combine data and server pods names")
-        server_data_pod_list = pod_list + data_pod_list
-        for count, pod_name in enumerate(self.pod_name_list):
-            count += 1
+        LOGGER.info("Step 2: Shutdown random %s (K) server pods by deleting deployment (unsafe)"
+                    " and verify cluster & remaining pods status", self.kvalue)
+        resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+            master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+            pod_prefix=[const.SERVER_POD_NAME_PREFIX], down_method=const.RESTORE_DEPLOYMENT_K8S,
+            kvalue=self.kvalue)
+        assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+        for pod_name in resp[1].keys():
             pod_data = list()
-            pod_data.append(
-                self.node_master_list[0].get_pod_hostname(pod_name=pod_name))  # hostname
-            LOGGER.info("Deleting %s server pod %s", count, pod_name)
-            resp = self.node_master_list[0].delete_deployment(pod_name=pod_name)
-            LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_false(resp[0], f"Failed to delete {count} server pod {pod_name} "
-                                               "by deleting deployment (unsafe)")
-            pod_data.append(resp[1])  # deployment_backup
-            pod_data.append(resp[2])  # deployment_name
-            self.restore_pod = self.deploy = True
-            self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+            pod_data.append(resp[1][pod_name]['hostname'])  # hostname
+            pod_data.append(resp[1][pod_name]['deployment_backup'])
+            pod_data.append(resp[1][pod_name]['deployment_name'])
+            self.pod_name_list.append(pod_name)
             self.pod_dict[pod_name] = pod_data
-            LOGGER.info("Deleted %s server pod %s by deleting deployment"
-                        " (unsafe)", count, pod_name)
-        LOGGER.info("Step 2: Successfully shutdown %s (K) server pods", self.kvalue)
-
-        LOGGER.info("Step 3: Check cluster status")
-        resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
-        assert_utils.assert_false(resp[0], resp)
-        LOGGER.info("Step 3: Cluster has some failures due to %s server pods has gone down.",
-                    self.kvalue)
-
-        LOGGER.info("Step 4: Check services status that were running on server pods "
-                    "which are deleted.")
-        counter = 0
-        for pod_name in self.pod_name_list:
-            hostname = self.pod_dict.get(pod_name)[0]
-            resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=[pod_name], fail=True,
-                                                               hostname=hostname)
-            LOGGER.debug("Services status on %s : %s", pod_name, resp)
-            if not resp[0]:
-                counter += 1
-            server_data_pod_list.remove(pod_name)
-        assert_utils.assert_equal(counter, 0, "Services on some server pods not stopped.")
-        LOGGER.info("Step 4: Services of server pods which are deleted are in offline state.")
-
-        LOGGER.info("Step 5: Check services status on remaining pods %s", server_data_pod_list)
-        resp = self.hlth_master_list[0].get_pod_svc_status(pod_list=server_data_pod_list,
-                                                           fail=False)
-        LOGGER.debug("Response: %s", resp)
-        assert_utils.assert_true(resp[0], resp)
-        LOGGER.info("Step 5: Verified services on remaining pods are in online state.")
-
-        LOGGER.info("Step 6: Download the uploaded object and verify checksum")
+        self.restore_method = const.RESTORE_DEPLOYMENT_K8S
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("Step 2: Successfully shutdown random %s (K) server pod %s. Verified cluster "
+                    "and services states are as expected & remaining pods status is online.",
+                    self.kvalue, self.pod_name_list)
+        LOGGER.info("Step 3: Download the uploaded object and verify checksum")
         resp = s3_test_obj.object_download(self.bucket_name, self.object_name, download_path)
         assert_utils.assert_true(resp[0], resp[1])
         download_checksum = self.ha_obj.cal_compare_checksum(file_list=[download_path],
@@ -1132,13 +789,11 @@ class TestMultiServerPodFailure:
                                   f"Failed to match checksum: {upload_checksum},"
                                   f" {download_checksum}")
         LOGGER.info("Matched checksum: %s, %s", upload_checksum, download_checksum)
-        LOGGER.info("Step 6: Successfully downloaded the object and verified the checksum")
-
+        LOGGER.info("Step 3: Successfully downloaded the object and verified the checksum")
         LOGGER.info("Removing files %s and %s", self.multipart_obj_path, download_path)
         sysutils.remove_file(self.multipart_obj_path)
         sysutils.remove_file(download_path)
-
-        LOGGER.info("Step 7: Create new bucket again and do multipart upload. "
+        LOGGER.info("Step 4: Create new bucket again and do multipart upload. "
                     "Download the object & verify checksum.")
         bucket_name = f"mp-bkt-{self.random_time}"
         object_name = f"mp-obj-{self.random_time}"
@@ -1154,7 +809,6 @@ class TestMultiServerPodFailure:
         obj_size = result[1]["ContentLength"]
         LOGGER.debug("Uploaded object info for %s is %s", bucket_name, result)
         assert_utils.assert_equal(obj_size, file_size * const.Sizes.MB)
-
         resp = s3_test_obj.object_download(bucket_name, object_name, download_path)
         LOGGER.info("Download object response: %s", resp)
         assert_utils.assert_true(resp[0], resp[1])
@@ -1164,18 +818,15 @@ class TestMultiServerPodFailure:
                                   f"Failed to match checksum: {upload_checksum1},"
                                   f" {download_checksum1}")
         LOGGER.info("Matched checksum: %s, %s", upload_checksum1, download_checksum1)
-        LOGGER.info("Step 7: Successfully created bucket and did multipart upload. "
+        LOGGER.info("Step 4: Successfully created bucket and did multipart upload. "
                     "Downloaded the object & verified the checksum.")
-
         LOGGER.info("COMPLETED: Test to verify multipart upload after all K server pods "
                     "down - unsafe shutdown.")
 
     # pylint: disable=too-many-statements
     @pytest.mark.ha
     @pytest.mark.lc
-    @pytest.mark.skip(reason="Multipart feature F-20C targeted for PI-7")
     @pytest.mark.tags("TEST-40584")
-    @CTFailOn(error_handler)
     def test_part_mpu_till_kserver_pods_fail(self):
         """
         This test tests partial multipart upload after each server pod is failed till K
@@ -1210,7 +861,7 @@ class TestMultiServerPodFailure:
         LOGGER.info("Successfully created IAM user with name %s", self.s3acc_name)
         self.s3_clean = {'s3_acc': {'accesskey': access_key, 'secretkey': secret_key,
                                     'user_name': self.s3acc_name}}
-        uploading_parts = random.sample(parts, 10)
+        uploading_parts = self.system_random.sample(parts, 10)
         LOGGER.info("Step 1: Perform partial multipart upload for %s parts out of total %s",
                     uploading_parts, len(parts))
         resp = self.ha_obj.partial_multipart_upload(s3_data=self.s3_clean,
@@ -1238,7 +889,7 @@ class TestMultiServerPodFailure:
                     "5GB object in multiple parts with every server pod shutdown", self.kvalue)
         LOGGER.info("Get server pod names to be deleted")
         pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
+        self.pod_name_list = self.system_random.sample(pod_list, self.kvalue)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")
@@ -1285,7 +936,7 @@ class TestMultiServerPodFailure:
             assert_utils.assert_true(resp[0], resp)
             LOGGER.info("Step 5: Services of remaining pods are in online state.")
 
-            uploading_parts = random.sample(parts, 10)
+            uploading_parts = self.system_random.sample(parts, 10)
             LOGGER.info("Step 6: Perform partial multipart upload for %s parts out of total %s",
                         uploading_parts, len(parts))
             resp = self.ha_obj.partial_multipart_upload(s3_data=self.s3_clean,
@@ -1383,7 +1034,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40577")
-    @CTFailOn(error_handler)
     def test_ios_during_kserver_pods_down(self):
         """
         This test tests continuous READs/WRITEs/DELETEs while pods are failing till K
@@ -1435,7 +1085,7 @@ class TestMultiServerPodFailure:
         LOGGER.info("Step 3: Start Continuous DELETEs in background on random %s buckets",
                     del_bucket)
         bucket_list = list(s3_data.keys())
-        get_random_buck = random.sample(bucket_list, del_bucket)
+        get_random_buck = self.system_random.sample(bucket_list, del_bucket)
         args = {'test_prefix': test_prefix_del, 'test_dir_path': self.test_dir_path,
                 'skipput': True, 'skipget': True, 'bkt_list': get_random_buck,
                 'output': del_output}
@@ -1482,7 +1132,7 @@ class TestMultiServerPodFailure:
                     "background", self.kvalue)
         LOGGER.info("Get server pod names to be deleted")
         pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
+        self.pod_name_list = self.system_random.sample(pod_list, self.kvalue)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")
@@ -1603,7 +1253,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40570")
-    @CTFailOn(error_handler)
     def test_cont_ios_during_kserver_pods_down_safe(self):
         """
         Test to verify continuous IOs while k server pods are failing one by one using
@@ -1634,7 +1283,7 @@ class TestMultiServerPodFailure:
                     "replicas=0 (safe)", self.kvalue)
         LOGGER.info("Get server pod names to be deleted")
         pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
+        self.pod_name_list = self.system_random.sample(pod_list, self.kvalue)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")
@@ -1722,7 +1371,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40571")
-    @CTFailOn(error_handler)
     def test_chunk_upload_during_kserver_pods_down(self):
         """
         Test chunk upload during k server pods going down using delete deployment (using jclient)
@@ -1770,7 +1418,7 @@ class TestMultiServerPodFailure:
                     " (unsafe)", self.kvalue)
         LOGGER.info("Get server pod names to be deleted")
         pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
+        self.pod_name_list = self.system_random.sample(pod_list, self.kvalue)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")
@@ -1884,9 +1532,7 @@ class TestMultiServerPodFailure:
     # pylint: disable-msg=too-many-locals
     @pytest.mark.ha
     @pytest.mark.lc
-    @pytest.mark.skip(reason="Multipart feature F-20C targeted for PI-7")
     @pytest.mark.tags("TEST-40585")
-    @CTFailOn(error_handler)
     def test_mpu_during_kserver_pods_shutdown(self):
         """
         This test tests multipart upload during server pods failure till K pods
@@ -1897,7 +1543,7 @@ class TestMultiServerPodFailure:
         file_size = HA_CFG["5gb_mpu_data"]["file_size"]
         total_parts = self.kvalue * 5 + HA_CFG["5gb_mpu_data"]["total_parts"]
         part_numbers = list(range(1, total_parts + 1))
-        random.shuffle(part_numbers)
+        self.system_random.shuffle(part_numbers)
         output = Queue()
         parts_etag = list()
         download_file = self.test_file + "_download"
@@ -1936,7 +1582,7 @@ class TestMultiServerPodFailure:
                     "upload in background", self.kvalue)
         LOGGER.info("Get server pod names to be deleted")
         pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
+        self.pod_name_list = self.system_random.sample(pod_list, self.kvalue)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")
@@ -2075,7 +1721,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.lc
     @pytest.mark.skip(reason="Not supported in RGW yet")
     @pytest.mark.tags("TEST-40583")
-    @CTFailOn(error_handler)
     def test_copy_object_during_kserver_pods_down(self):
         """
         Test to Verify copy object during server pods failure till K pods
@@ -2146,7 +1791,7 @@ class TestMultiServerPodFailure:
                     "(unsafe)", self.kvalue)
         LOGGER.info("Get server pod names to be deleted")
         pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
+        self.pod_name_list = self.system_random.sample(pod_list, self.kvalue)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")
@@ -2276,7 +1921,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40576")
-    @CTFailOn(error_handler)
     def test_deletes_during_kserver_pods_down(self):
         """
         This test tests continuous DELETEs while pods are failing till K server
@@ -2323,7 +1967,7 @@ class TestMultiServerPodFailure:
         LOGGER.info("Step 2: Start Continuous DELETEs in background on random %s buckets",
                     del_bucket)
         bucket_list = list(s3_data.keys())
-        get_random_buck = random.sample(bucket_list, del_bucket)
+        get_random_buck = self.system_random.sample(bucket_list, del_bucket)
         args = {'test_prefix': self.test_prefix, 'test_dir_path': self.test_dir_path,
                 'skipput': True, 'skipget': True, 'bkt_list': get_random_buck,
                 'output': del_output}
@@ -2338,7 +1982,7 @@ class TestMultiServerPodFailure:
                     "background", self.kvalue)
         LOGGER.info("Get server pod names to be deleted")
         pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
+        self.pod_name_list = self.system_random.sample(pod_list, self.kvalue)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")
@@ -2460,7 +2104,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40575")
-    @CTFailOn(error_handler)
     def test_writes_during_kserver_pods_down(self):
         """
         This test tests continuous WRITEs while pods are failing till K server
@@ -2489,7 +2132,7 @@ class TestMultiServerPodFailure:
                     "background", self.kvalue)
         LOGGER.info("Get server pod names to be deleted")
         pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
+        self.pod_name_list = self.system_random.sample(pod_list, self.kvalue)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")
@@ -2578,7 +2221,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40574")
-    @CTFailOn(error_handler)
     def test_reads_during_kserver_pods_down(self):
         """
         This test tests READs while pods are failing till K server pods down - unsafe shutdown
@@ -2612,7 +2254,7 @@ class TestMultiServerPodFailure:
                     "written data in background", self.kvalue)
         LOGGER.info("Get server pod names to be deleted")
         pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
+        self.pod_name_list = self.system_random.sample(pod_list, self.kvalue)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")
@@ -2702,7 +2344,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-40572")
-    @CTFailOn(error_handler)
     def test_reads_writes_during_kserver_pods_down(self):
         """
         This test tests continuous READs/WRITEs while pods are failing till K
@@ -2732,7 +2373,7 @@ class TestMultiServerPodFailure:
                     "in background", self.kvalue)
         LOGGER.info("Get server pod names to be deleted")
         pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
-        self.pod_name_list = random.sample(pod_list, self.kvalue)
+        self.pod_name_list = self.system_random.sample(pod_list, self.kvalue)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")
@@ -2815,10 +2456,9 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-42054")
-    @CTFailOn(error_handler)
     def test_ios_till_single_server_pod_running(self):
         """
-        Test to verify IOs after each pod failure till only single server pod is running."
+        Test to verify IOs after each pod failure till only single server pod is running.
         """
         LOGGER.info("Started: Test to verify IOs after each pod failure till only "
                     "single server pod remains running")
@@ -2837,7 +2477,7 @@ class TestMultiServerPodFailure:
         LOGGER.info("Get server pod names to be deleted")
         pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.SERVER_POD_NAME_PREFIX)
         value = len(pod_list) - 1
-        self.pod_name_list = random.sample(pod_list, value)
+        self.pod_name_list = self.system_random.sample(pod_list, value)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")
@@ -2910,7 +2550,6 @@ class TestMultiServerPodFailure:
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-42053")
-    @CTFailOn(error_handler)
     def test_conti_ios_till_single_server_pod_running(self):
         """
         This test tests continuous READs/WRITEs/DELETEs while server pods are failing till only one
@@ -2964,7 +2603,7 @@ class TestMultiServerPodFailure:
         LOGGER.info("Step 3: Start Continuous DELETEs in background on random %s buckets",
                     del_bucket)
         bucket_list = list(s3_data.keys())
-        get_random_buck = random.sample(bucket_list, del_bucket)
+        get_random_buck = self.system_random.sample(bucket_list, del_bucket)
         args = {'test_prefix': test_prefix_del, 'test_dir_path': self.test_dir_path,
                 'skipput': True, 'skipget': True, 'bkt_list': get_random_buck,
                 'output': del_output}
@@ -3006,7 +2645,7 @@ class TestMultiServerPodFailure:
         LOGGER.info("Step 6: Shutdown server pods one by one while continuous IOs in "
                     "background")
         LOGGER.info("Get server pod names to be deleted")
-        self.pod_name_list = random.sample(pod_list, value)
+        self.pod_name_list = self.system_random.sample(pod_list, value)
         LOGGER.info("Get data pod names")
         data_pod_list = self.node_master_list[0].get_all_pods(pod_prefix=const.POD_NAME_PREFIX)
         LOGGER.info("Combine data and server pods names")


### PR DESCRIPTION
Signed-off-by: RAHUL HATWAR <rahulchandrakant.hatwar@seagate.com>

# Problem Statement
- Optimize for multi server pod failure1 (8 tests)

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide

Collection logs output : 

d': 'TEST-43184', 'marks': ['s3_ops', 'sanity']}, {'nodeid': 'tests/s3/versioning/test_versioning_delete_objects.py::TestVersioningDeleteObjects::test_delete_objects_multipart_suspended_43185', 'test_id': 'TEST-43185', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::download_and_check', 'test_id': '', 'marks': []}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_object_preexisting_32739', 'test_id': 'TEST-32739', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_object_versioned_bucket_32731', 'test_id': 'TEST-32731', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_object_versioned_bucket_32729', 'test_id': 'TEST-32729', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[None]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Enabled]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Suspended]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_preexist_mpu_versioning_enabled_bkt_41284', 'test_id': 'TEST-41284', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_ver_enabled_bkt_41285', 'test_id': 'TEST-41285', 'marks': ['s3_ops', 'sanity']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_versioning_suspended_bkt_41286', 'test_id': 'TEST-41286', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_del_versioning_enabled_bkt_41287', 'test_id': 'TEST-41287', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_abort_multipart_upload_does_not_create_a_new_version_41288', 'test_id': 'TEST-41288', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_upload_multiple_versions_to_multipart_uploaded_object_in_versioned_bucket_41289', 'test_id': 'TEST-41289', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_upload_new_versions_to_existing_objects_using_multipart_upload_41290', 'test_id': 'TEST-41290', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_preexisting_32724', 'test_id': 'TEST-32724', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_enabled_32728', 'test_id': 'TEST-32728', 'marks': ['s3_ops', 'sanity']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_suspended_32733', 'test_id': 'TEST-32733', 'marks': ['s3_ops']}, {'nodeid': 'tests/security/test_cortx_port_scanner_kubectl_svc.py::test_cortx_port_scanner_kubectl_svc', 'test_id': 'TEST-34217', 'marks': ['security']}, {'nodeid': 'tests/security/test_cortx_port_scanner_netstat.py::test_cortx_port_scanner_netstat', 'test_id': 'TEST-34218', 'marks': ['security']}] created at /root/workspace/cortx-test-1/log/te_meta.json
Successfully unmounted directory

==================================================== 2336 tests collected in 9.06s =====================================================