### PR TITLE
CORTX-33458 RGW error message correction seen for copy operation of more than 5GB object

### DIFF
--- a/commons/error_messages.py
+++ b/commons/error_messages.py
@@ -38,9 +38,8 @@ RGW_ERR_DUPLICATE_BKT_NAME = ("An error occurred (BucketAlreadyExists) when call
 CORTX_ERR_DUPLICATE_BKT_NAME = ("An error occurred (BucketAlreadyOwnedByYou) when calling"
                                 "the CreateBucket operation: Your previous request to create "
                                 "the named bucket succeeded and you already own it.")
-RGW_ERR_COPY_OBJ = ("An error occurred (InvalidRequest) when calling the CopyObject operation:"
-                    " The specified copy source is larger than the maximum allowable size for a "
-                    "copy source: 5368709120")
+RGW_ERR_COPY_OBJ = ("An error occurred (EntityTooLarge) when calling the CopyObject "
+                    "operation: Unknown")
 CORTX_ERR_COPY_OBJ = ("An error occurred (InvalidRequest) when calling the CopyObject operation:"
                       " The specified copy source is larger than the maximum allowable size for a "
                       "copy source: 5368709120")


### PR DESCRIPTION
Signed-off-by: Kapil Jinna <kapil.jinna@seagate.com>

# Problem Statement
[https://jts.seagate.com/browse/TEST-19846] was failing because of error message not matching as per Ceph RGW behavior when copy operation of more than 5 GB object was performed .
Added the correct Error message as observed in Ceph .

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [x] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide