### PR TITLE
sanity marker added in tagging tests

### DIFF
--- a/tests/s3/test_bucket_tagging.py
+++ b/tests/s3/test_bucket_tagging.py
@@ -129,6 +129,7 @@ class TestBucketTagging:
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
+    @pytest.mark.sanity
     @pytest.mark.s3_bucket_tags
     @pytest.mark.usefixtures("create_bucket")
     @pytest.mark.tags("TEST-5519")

--- a/tests/s3/test_object_tagging.py
+++ b/tests/s3/test_object_tagging.py
@@ -124,6 +124,7 @@ class TestObjectTagging:
         self.log.info("Bucket is created with name %s", self.bucket_name)
 
     @pytest.mark.s3_ops
+    @pytest.mark.sanity
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5549")
     def test_verify_putobj_tagging_2457(self):
@@ -142,6 +143,7 @@ class TestObjectTagging:
         self.log.info("Verify PUT object tagging")
 
     @pytest.mark.s3_ops
+    @pytest.mark.sanity
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5557")
     def test_getobj_tagging_2458(self):
@@ -160,6 +162,7 @@ class TestObjectTagging:
         self.log.info("Verify GET object tagging")
 
     @pytest.mark.s3_ops
+    @pytest.mark.sanity
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-5561")
     def test_delobj_tagging_2459(self):
@@ -185,6 +188,7 @@ class TestObjectTagging:
 
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_tags
+    @pytest.mark.sanity
     @pytest.mark.usefixtures("create_bucket")
     @pytest.mark.tags("TEST-5547")
     def test_putobj_taggingsupport_2460(self):
@@ -224,6 +228,7 @@ class TestObjectTagging:
         self.log.info("Verify get object with tagging support")
 
     @pytest.mark.s3_ops
+    @pytest.mark.sanity
     @pytest.mark.s3_object_tags
     @pytest.mark.regression
     @pytest.mark.usefixtures("create_bucket")
@@ -1039,6 +1044,7 @@ class TestObjectTagging:
         self.log.info("verify Get object tags count using GET object on non tagged object")
 
     @pytest.mark.s3_ops
+    @pytest.mark.sanity
     @pytest.mark.s3_object_tags
     @pytest.mark.tags("TEST-42782")
     def test_object_tag_count_get_object_42782(self):

--- a/tests/s3/versioning/test_delete_object_tagging.py
+++ b/tests/s3/versioning/test_delete_object_tagging.py
@@ -180,6 +180,7 @@ class TestTaggingDeleteObject:
 
     # pylint:disable-msg=too-many-statements
     @pytest.mark.s3_ops
+    @pytest.mark.sanity
     @pytest.mark.tags("TEST-40436")
     @CTFailOn(error_handler)
     def test_del_obj_tag_40436(self):

--- a/tests/s3/versioning/test_get_put_object_tagging.py
+++ b/tests/s3/versioning/test_get_put_object_tagging.py
@@ -275,6 +275,7 @@ class TestGetPutObjectTagging:
                     " a versioning enabled bucket ")
 
     @pytest.mark.s3_ops
+    @pytest.mark.sanity
     @pytest.mark.tags("TEST-40431")
     def test_get_put_obj_tags_ver_bkt_40431(self):
         """Test GET and PUT object tagging in a versioning enabled bucket"""


### PR DESCRIPTION
Signed-off-by: akshaym99 <akshay.s.mankar@seagate.com>

# Problem Statement
- Sanity marker added in tagging tests, after verification of bug.

# Design
-  Bug: https://jts.seagate.com/browse/CORTX-33574

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide