### PR TITLE
Data server pod restart - Test-45510

### DIFF
--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -459,12 +459,12 @@ class TestDataServerPodRestart:
             resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                         log_prefix=self.test_prefix_deg,
                                                         skipcleanup=True, setup_s3bench=False)
-        else:
-            LOGGER.info("Step 4: Create new objects and perform WRITEs/READs/Verify with variable "
-                        "object sizes in degraded mode")
-            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                        log_prefix=self.test_prefix,
-                                                        skipcleanup=True, setup_s3bench=False)
+            assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 4: Create new objects and perform WRITEs/READs/Verify with variable "
+                    "object sizes in degraded mode")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix,
+                                                    skipcleanup=True, setup_s3bench=False)
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 4: Performed WRITEs/READs/Verify with variable sizes objects in "
                     "degraded mode")

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -25,6 +25,7 @@ HA test suite for single data and server Pod restart
 import logging
 import secrets
 import time
+import re
 from time import perf_counter_ns
 
 import pytest
@@ -106,24 +107,29 @@ class TestDataServerPodRestart:
         resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Precondition: Verified cluster is up and running and all pods are online.")
+        convert = lambda text: int(text) if text.isdigit() else text
+        alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
         LOGGER.info("Get %s and %s pods to be deleted", const.POD_NAME_PREFIX,
                     const.SERVER_POD_NAME_PREFIX)
-        self.combine_delete_pod = list()
-        self.combine_set_name = list()
+        self.pod_dict = dict()
         for prefix in [const.POD_NAME_PREFIX, const.SERVER_POD_NAME_PREFIX]:
+            self.pod_list = list()
             sts_dict = self.node_master_list[0].get_sts_pods(pod_prefix=prefix)
             sts_list = list(sts_dict.keys())
             LOGGER.debug("%s Statefulset: %s", prefix, sts_list)
             sts = self.system_random.sample(sts_list, 1)[0]
-            self.delete_pod = sts_dict[sts][-1]
+            sts_dict_val = sorted(sts_dict.get(sts), key=alphanum_key)
+            self.delete_pod = sts_dict_val[-1]
             LOGGER.info("Pod to be deleted is %s", self.delete_pod)
             self.set_type, self.set_name = self.node_master_list[0].get_set_type_name(
                 pod_name=self.delete_pod)
-            self.combine_delete_pod.append(self.delete_pod)
-            self.combine_set_name.append(self.set_name)
+            self.pod_list.append(self.delete_pod)
+            self.pod_list.append(self.set_name)
             resp = self.node_master_list[0].get_num_replicas(self.set_type, self.set_name)
             assert_utils.assert_true(resp[0], resp)
             self.num_replica = int((resp[1]))
+            self.pod_list.append(self.num_replica)
+            self.pod_dict[prefix] = self.pod_list
         LOGGER.info("COMPLETED: Setup operations. ")
 
     def teardown_method(self):
@@ -132,18 +138,19 @@ class TestDataServerPodRestart:
         """
         LOGGER.info("STARTED: Teardown Operations.")
         if self.restore_pod:
-            for set_name in self.combine_set_name:
+            for pod in self.pod_dict:
+                self.restore_method = self.pod_dict.get(pod)[-1]
                 resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
                                                restore_method=self.restore_method,
                                                restore_params={
-                                                   "deployment_name": self.deployment_name,
+                                                   "deployment_name": self.pod_dict.get(pod)[-2],
                                                    "deployment_backup": self.deployment_backup,
-                                                   "num_replica": self.num_replica,
-                                                   "set_name": set_name})
+                                                   "num_replica": self.pod_dict.get(pod)[2],
+                                                   "set_name": self.pod_dict.get(pod)[1]})
                 LOGGER.debug("Response: %s", resp)
                 assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method}"
                                                   " way")
-            LOGGER.info("Successfully restored pod by %s way", self.restore_method)
+                LOGGER.info("Successfully restored pod by %s way", self.restore_method)
         if self.s3_clean:
             LOGGER.info("Cleanup: Cleaning created s3 accounts and buckets.")
             resp = self.ha_obj.delete_s3_acc_buckets_objects(self.s3_clean)
@@ -422,20 +429,21 @@ class TestDataServerPodRestart:
                                                     log_prefix=self.test_prefix, skipcleanup=True)
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 1: Performed WRITEs/READs/Verify with variable sizes objects")
-        num_replica = self.num_replica - 1
         LOGGER.info("Step 2: Shutdown data and server pod with replica method and verify cluster &"
                     " remaining pods status")
-        resp = self.ha_obj.delete_kpod_with_shutdown_methods(
-            master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
-            pod_prefix=[const.POD_NAME_PREFIX, const.SERVER_POD_NAME_PREFIX],
-            delete_pod=self.combine_delete_pod, num_replica=num_replica)
-        # Assert if empty dictionary
-        assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
-        for pod_name in resp[1]:
-            pod_data = list()
-            pod_data.append(resp[1][pod_name]['deployment_name'])  # deployment_name
-            self.pod_name_list.append(pod_name)
-            self.restore_method = resp[1][pod_name]['method']
+        for pod_prefix in self.pod_dict:
+            num_replica = self.pod_dict[pod_prefix][-1] - 1
+            resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+                master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+                pod_prefix=[pod_prefix], delete_pod=[self.pod_dict.get(pod_prefix)[0]],
+                num_replica=num_replica)
+            # Assert if empty dictionary
+            assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+            pod_name = list(resp[1].keys())[0]
+            self.pod_dict[pod_prefix].append(resp[1][pod_name]['deployment_name'])
+            self.pod_dict[pod_prefix].append(resp[1][pod_name]['method'])
+            assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+            LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
         self.restore_pod = True
         assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
         LOGGER.info("Step 2: Successfully shutdown data and server pod - %s. Verified cluster and "
@@ -449,36 +457,42 @@ class TestDataServerPodRestart:
         LOGGER.info("Step 3: Performed READs/Verify on data written in healthy cluster.")
         LOGGER.info("Step 4: Create new bucket and perform WRITEs/READs/Verify with variable "
                     "object sizes in degraded mode")
-        t_t = str(perf_counter_ns())
-        self.test_prefix_deg = f'test-45510-deg-{t_t}'
-        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                    log_prefix=self.test_prefix_deg,
-                                                    skipcleanup=True, setup_s3bench=False)
+        if CMN_CFG["dtm0_disabled"]:
+            t_t = str(perf_counter_ns())
+            self.test_prefix_deg = f'test-45510-deg-{t_t}'
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_deg,
+                                                        skipcleanup=True, setup_s3bench=False)
+        else:
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix,
+                                                        skipcleanup=True, setup_s3bench=False)
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 4: Performed WRITEs/READs/Verify with variable sizes objects in "
                     "degraded mode")
         LOGGER.info("Step 5: Restore data and server pod and check cluster status.")
-        for set_name in self.combine_set_name:
+        for pod in self.pod_dict:
+            self.restore_method = self.pod_dict.get(pod)[-1]
             resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
                                            restore_method=self.restore_method,
-                                           restore_params={"deployment_name": self.deployment_name,
-                                                           "deployment_backup":
-                                                               self.deployment_backup,
-                                                           "num_replica": self.num_replica,
-                                                           "set_name": set_name})
+                                           restore_params={
+                                               "deployment_name": self.pod_dict.get(pod)[-2],
+                                               "deployment_backup": self.deployment_backup,
+                                               "num_replica": self.pod_dict.get(pod)[2],
+                                               "set_name": self.pod_dict.get(pod)[1]})
             LOGGER.debug("Response: %s", resp)
-            assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method}"
-                                              "way")
-        LOGGER.info("Successfully restored pod by %s way", self.restore_method)
+            assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method} way")
+            LOGGER.info("Successfully restored pod by %s way", self.restore_method)
         LOGGER.info("Step 5: Successfully started data and server pod and cluster is online.")
         self.restore_pod = False
-        LOGGER.info("Step 6: Perform READs and verify DI on the data written in degraded mode")
-        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                    log_prefix=self.test_prefix_deg,
-                                                    skipwrite=True, skipcleanup=True,
-                                                    setup_s3bench=False)
-        assert_utils.assert_true(resp[0], resp[1])
-        LOGGER.info("Step 6: Successfully run READ/Verify on data written in degraded mode")
+        if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("Step 6: Perform READs and verify DI on the data written in degraded mode")
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_deg,
+                                                        skipwrite=True, skipcleanup=True,
+                                                        setup_s3bench=False)
+            assert_utils.assert_true(resp[0], resp[1])
+            LOGGER.info("Step 6: Successfully run READ/Verify on data written in degraded mode")
         LOGGER.info("Step 7: Perform READ/Verify on data written in healthy mode")
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                     log_prefix=self.test_prefix, skipwrite=True,
@@ -487,10 +501,11 @@ class TestDataServerPodRestart:
         LOGGER.info("Step 7: Successfully run READ/Verify on data written in healthy mode")
         LOGGER.info("Step 8: Create new IAM user and buckets, Perform WRITEs-READs-Verify with "
                     "variable object sizes after data and server pod restart")
-        users = self.mgnt_ops.create_account_users(nusers=1)
-        t_t = str(perf_counter_ns())
-        self.test_prefix = f'test-45510-restart-{t_t}'
-        self.s3_clean.update(users)
+        if CMN_CFG["dtm0_disabled"]:
+            users = self.mgnt_ops.create_account_users(nusers=1)
+            t_t = str(perf_counter_ns())
+            self.test_prefix = f'test-45510-restart-{t_t}'
+            self.s3_clean.update(users)
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                     log_prefix=self.test_prefix,
                                                     skipcleanup=True, setup_s3bench=False)

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -427,8 +427,8 @@ class TestDataServerPodRestart:
                                                     log_prefix=self.test_prefix, skipcleanup=True)
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 1: Performed WRITEs/READs/Verify with variable sizes objects")
-        LOGGER.info("Step 2: Shutdown data and server pod with replica method and verify cluster &"
-                    " remaining pods status")
+        LOGGER.info("Step 2: Shutdown one data and one server pod with replica method and verify"
+                    " cluster & remaining pods status")
         for pod_prefix in self.pod_dict:
             num_replica = self.pod_dict[pod_prefix][-1] - 1
             resp = self.ha_obj.delete_kpod_with_shutdown_methods(
@@ -444,8 +444,8 @@ class TestDataServerPodRestart:
             LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
         self.restore_pod = True
         assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
-        LOGGER.info("Step 2: Successfully shutdown data and server pod. Verified cluster and "
-                    "services states are as expected & remaining pods status is online")
+        LOGGER.info("Step 2: Successfully shutdown one data and one server pod. Verified cluster "
+                    "and services states are as expected & remaining pods status is online")
         LOGGER.info("STEP 3: Perform READs/Verify on data written in healthy cluster.")
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                     log_prefix=self.test_prefix, skipwrite=True,

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -166,8 +166,8 @@ class TestDataServerPodRestart:
             resp = sysutils.check_ping(host=self.node_ip)
             assert_utils.assert_true(resp, "Interface is still not up.")
         LOGGER.info("Cleanup: Check cluster status and start it if not up.")
-        resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
-        assert_utils.assert_true(resp[0], resp[1])
+        resp = self.ha_obj.poll_cluster_status(self.node_master_list[0])
+        assert_utils.assert_true(resp[0], resp)
         LOGGER.info("Done: Teardown completed.")
 
     # pylint: disable=too-many-statements

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -62,7 +62,6 @@ class TestDataServerPodRestart:
         cls.node_master_list = list()
         cls.hlth_master_list = list()
         cls.node_worker_list = list()
-        cls.pod_name_list = list()
         cls.ha_obj = HAK8s()
         cls.random_time = cls.s3_clean = cls.test_prefix = cls.test_prefix_deg = None
         cls.s3acc_name = cls.s3acc_email = cls.bucket_name = cls.object_name = cls.node_name = None
@@ -446,9 +445,8 @@ class TestDataServerPodRestart:
             LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
         self.restore_pod = True
         assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
-        LOGGER.info("Step 2: Successfully shutdown data and server pod - %s. Verified cluster and "
-                    "services states are as expected & remaining pods status is online.",
-                    self.pod_name_list)
+        LOGGER.info("Step 2: Successfully shutdown data and server pod. Verified cluster and "
+                    "services states are as expected & remaining pods status is online")
         LOGGER.info("STEP 3: Perform READs/Verify on data written in healthy cluster.")
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                     log_prefix=self.test_prefix, skipwrite=True,

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -99,7 +99,6 @@ class TestDataServerPodRestart:
         self.s3_clean = dict()
         self.restore_pod = self.restore_method = self.deployment_name = self.set_name = None
         self.deployment_backup = None
-        self.num_replica = 1
         self.s3acc_name = f"ha_s3acc_{int(perf_counter_ns())}"
         self.s3acc_email = f"{self.s3acc_name}@seagate.com"
         LOGGER.info("Precondition: Verify cluster is up and running and all pods are online.")
@@ -137,15 +136,16 @@ class TestDataServerPodRestart:
         """
         LOGGER.info("STARTED: Teardown Operations.")
         if self.restore_pod:
-            for pod in self.pod_dict:
-                self.restore_method = self.pod_dict.get(pod)[-1]
+            for pod_prefix in self.pod_dict:
+                self.restore_method = self.pod_dict.get(pod_prefix)[-1]
                 resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
                                                restore_method=self.restore_method,
                                                restore_params={
-                                                   "deployment_name": self.pod_dict.get(pod)[-2],
+                                                   "deployment_name":
+                                                       self.pod_dict.get(pod_prefix)[-2],
                                                    "deployment_backup": self.deployment_backup,
-                                                   "num_replica": self.pod_dict.get(pod)[2],
-                                                   "set_name": self.pod_dict.get(pod)[1]})
+                                                   "num_replica": self.pod_dict.get(pod_prefix)[2],
+                                                   "set_name": self.pod_dict.get(pod_prefix)[1]})
                 LOGGER.debug("Response: %s", resp)
                 assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method}"
                                                   " way")
@@ -469,15 +469,15 @@ class TestDataServerPodRestart:
         LOGGER.info("Step 4: Performed WRITEs/READs/Verify with variable sizes objects in "
                     "degraded mode")
         LOGGER.info("Step 5: Restore data and server pod and check cluster status.")
-        for pod in self.pod_dict:
-            self.restore_method = self.pod_dict.get(pod)[-1]
+        for pod_prefix in self.pod_dict:
+            self.restore_method = self.pod_dict.get(pod_prefix)[-1]
             resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
                                            restore_method=self.restore_method,
                                            restore_params={
-                                               "deployment_name": self.pod_dict.get(pod)[-2],
+                                               "deployment_name": self.pod_dict.get(pod_prefix)[-2],
                                                "deployment_backup": self.deployment_backup,
-                                               "num_replica": self.pod_dict.get(pod)[2],
-                                               "set_name": self.pod_dict.get(pod)[1]})
+                                               "num_replica": self.pod_dict.get(pod_prefix)[2],
+                                               "set_name": self.pod_dict.get(pod_prefix)[1]})
             LOGGER.debug("Response: %s", resp)
             assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method} way")
             LOGGER.info("Successfully restored pod by %s way", self.restore_method)

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -56,11 +56,12 @@ class TestDataServerPodRestart:
         """
         LOGGER.info("STARTED: Setup Module operations.")
         cls.num_nodes = len(CMN_CFG["nodes"])
-        cls.username = []
-        cls.password = []
-        cls.node_master_list = []
-        cls.hlth_master_list = []
-        cls.node_worker_list = []
+        cls.username = list()
+        cls.password = list()
+        cls.node_master_list = list()
+        cls.hlth_master_list = list()
+        cls.node_worker_list = list()
+        cls.pod_name_list = list()
         cls.ha_obj = HAK8s()
         cls.random_time = cls.s3_clean = cls.test_prefix = cls.test_prefix_deg = None
         cls.s3acc_name = cls.s3acc_email = cls.bucket_name = cls.object_name = cls.node_name = None
@@ -96,23 +97,57 @@ class TestDataServerPodRestart:
         self.restore_node = False
         self.restore_ip = False
         self.s3_clean = dict()
+        self.restore_pod = self.restore_method = self.deployment_name = self.set_name = None
+        self.deployment_backup = None
+        self.num_replica = 1
         self.s3acc_name = f"ha_s3acc_{int(perf_counter_ns())}"
         self.s3acc_email = f"{self.s3acc_name}@seagate.com"
         LOGGER.info("Precondition: Verify cluster is up and running and all pods are online.")
         resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Precondition: Verified cluster is up and running and all pods are online.")
+        LOGGER.info("Get %s and %s pods to be deleted", const.POD_NAME_PREFIX,
+                    const.SERVER_POD_NAME_PREFIX)
+        self.combine_delete_pod = list()
+        self.combine_set_name = list()
+        for prefix in [const.POD_NAME_PREFIX, const.SERVER_POD_NAME_PREFIX]:
+            sts_dict = self.node_master_list[0].get_sts_pods(pod_prefix=prefix)
+            sts_list = list(sts_dict.keys())
+            LOGGER.debug("%s Statefulset: %s", prefix, sts_list)
+            sts = self.system_random.sample(sts_list, 1)[0]
+            self.delete_pod = sts_dict[sts][-1]
+            LOGGER.info("Pod to be deleted is %s", self.delete_pod)
+            self.set_type, self.set_name = self.node_master_list[0].get_set_type_name(
+                pod_name=self.delete_pod)
+            self.combine_delete_pod.append(self.delete_pod)
+            self.combine_set_name.append(self.set_name)
+            resp = self.node_master_list[0].get_num_replicas(self.set_type, self.set_name)
+            assert_utils.assert_true(resp[0], resp)
+            self.num_replica = int((resp[1]))
         LOGGER.info("COMPLETED: Setup operations. ")
 
     def teardown_method(self):
         """
         This function will be invoked after each test function in the module.
         """
+        LOGGER.info("STARTED: Teardown Operations.")
+        if self.restore_pod:
+            for set_name in self.combine_set_name:
+                resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
+                                               restore_method=self.restore_method,
+                                               restore_params={
+                                                   "deployment_name": self.deployment_name,
+                                                   "deployment_backup": self.deployment_backup,
+                                                   "num_replica": self.num_replica,
+                                                   "set_name": set_name})
+                LOGGER.debug("Response: %s", resp)
+                assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method}"
+                                                  " way")
+            LOGGER.info("Successfully restored pod by %s way", self.restore_method)
         if self.s3_clean:
             LOGGER.info("Cleanup: Cleaning created s3 accounts and buckets.")
             resp = self.ha_obj.delete_s3_acc_buckets_objects(self.s3_clean)
             assert_utils.assert_true(resp[0], resp[1])
-        LOGGER.info("STARTED: Teardown Operations.")
         if self.restore_node:
             LOGGER.info("Cleanup: Power on the %s down node.", self.node_name)
             resp = self.ha_obj.host_power_on(host=self.node_name)
@@ -125,9 +160,7 @@ class TestDataServerPodRestart:
             assert_utils.assert_true(resp, "Interface is still not up.")
         LOGGER.info("Cleanup: Check cluster status and start it if not up.")
         resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
-        if not resp[0]:
-            resp = self.ha_obj.restart_cluster(self.node_master_list[0])
-            assert_utils.assert_true(resp[0], resp[1])
+        assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Done: Teardown completed.")
 
     # pylint: disable=too-many-statements
@@ -370,3 +403,99 @@ class TestDataServerPodRestart:
             LOGGER.info("Step 10: IOs completed successfully.")
         LOGGER.info("COMPLETED: Verify IOs before and after data pod restart, "
                     "pod shutdown by making mgmt ip of worker node down")
+
+    @pytest.mark.ha
+    @pytest.mark.lc
+    @pytest.mark.tags("TEST-45510")
+    def test_io_data_server_pod_restart(self):
+        """
+        Verify IO when any 1 data pod and any 1 server pod restart by replica method
+        """
+        LOGGER.info("STARTED: Verify IO when any 1 data pod and any 1 server pod restart by "
+                    "replica method")
+        LOGGER.info("STEP 1: Perform WRITEs/READs/Verify with variable object sizes")
+        users = self.mgnt_ops.create_account_users(nusers=1)
+        t_t = str(perf_counter_ns())
+        self.test_prefix = f'test-45510-{t_t}'
+        self.s3_clean.update(users)
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipcleanup=True)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 1: Performed WRITEs/READs/Verify with variable sizes objects")
+        num_replica = self.num_replica - 1
+        LOGGER.info("Step 2: Shutdown data and server pod with replica method and verify cluster &"
+                    " remaining pods status")
+        resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+            master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+            pod_prefix=[const.POD_NAME_PREFIX, const.SERVER_POD_NAME_PREFIX],
+            delete_pod=self.combine_delete_pod, num_replica=num_replica)
+        # Assert if empty dictionary
+        assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+        for pod_name in resp[1]:
+            pod_data = list()
+            pod_data.append(resp[1][pod_name]['deployment_name'])  # deployment_name
+            self.pod_name_list.append(pod_name)
+            self.restore_method = resp[1][pod_name]['method']
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("Step 2: Successfully shutdown data and server pod - %s. Verified cluster and "
+                    "services states are as expected & remaining pods status is online.",
+                    self.pod_name_list)
+        LOGGER.info("STEP 3: Perform READs/Verify on data written in healthy cluster.")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipwrite=True,
+                                                    skipcleanup=True, setup_s3bench=False)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 3: Performed READs/Verify on data written in healthy cluster.")
+        LOGGER.info("Step 4: Create new bucket and perform WRITEs/READs/Verify with variable "
+                    "object sizes in degraded mode")
+        t_t = str(perf_counter_ns())
+        self.test_prefix_deg = f'test-45510-deg-{t_t}'
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix_deg,
+                                                    skipcleanup=True, setup_s3bench=False)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 4: Performed WRITEs/READs/Verify with variable sizes objects in "
+                    "degraded mode")
+        LOGGER.info("Step 5: Restore data and server pod and check cluster status.")
+        for set_name in self.combine_set_name:
+            resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
+                                           restore_method=self.restore_method,
+                                           restore_params={"deployment_name": self.deployment_name,
+                                                           "deployment_backup":
+                                                               self.deployment_backup,
+                                                           "num_replica": self.num_replica,
+                                                           "set_name": set_name})
+            LOGGER.debug("Response: %s", resp)
+            assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method}"
+                                              "way")
+        LOGGER.info("Successfully restored pod by %s way", self.restore_method)
+        LOGGER.info("Step 5: Successfully started data and server pod and cluster is online.")
+        self.restore_pod = False
+        LOGGER.info("Step 6: Perform READs and verify DI on the data written in degraded mode")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix_deg,
+                                                    skipwrite=True, skipcleanup=True,
+                                                    setup_s3bench=False)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 6: Successfully run READ/Verify on data written in degraded mode")
+        LOGGER.info("Step 7: Perform READ/Verify on data written in healthy mode")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipwrite=True,
+                                                    skipcleanup=True, setup_s3bench=False)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 7: Successfully run READ/Verify on data written in healthy mode")
+        LOGGER.info("Step 8: Create new IAM user and buckets, Perform WRITEs-READs-Verify with "
+                    "variable object sizes after data and server pod restart")
+        users = self.mgnt_ops.create_account_users(nusers=1)
+        t_t = str(perf_counter_ns())
+        self.test_prefix = f'test-45510-restart-{t_t}'
+        self.s3_clean.update(users)
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix,
+                                                    skipcleanup=True, setup_s3bench=False)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 8: Performed WRITEs-READs-Verify with variable sizes objects after "
+                    "data and server pod restart")
+        LOGGER.info("COMPLETED: Verify IO when any 1 data pod and any 1 server pod restart by "
+                    "replica method")

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -421,8 +421,7 @@ class TestDataServerPodRestart:
                     "replica method")
         LOGGER.info("STEP 1: Perform WRITEs/READs/Verify with variable object sizes")
         users = self.mgnt_ops.create_account_users(nusers=1)
-        t_t = str(perf_counter_ns())
-        self.test_prefix = f'test-45510-{t_t}'
+        self.test_prefix = f'test-45510-{int(perf_counter_ns())}'
         self.s3_clean.update(users)
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                     log_prefix=self.test_prefix, skipcleanup=True)
@@ -453,15 +452,16 @@ class TestDataServerPodRestart:
                                                     skipcleanup=True, setup_s3bench=False)
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 3: Performed READs/Verify on data written in healthy cluster.")
-        LOGGER.info("Step 4: Create new bucket and perform WRITEs/READs/Verify with variable "
-                    "object sizes in degraded mode")
         if CMN_CFG["dtm0_disabled"]:
-            t_t = str(perf_counter_ns())
-            self.test_prefix_deg = f'test-45510-deg-{t_t}'
+            LOGGER.info("Step 4: Create new bucket and perform WRITEs/READs/Verify with variable "
+                        "object sizes in degraded mode")
+            self.test_prefix_deg = f'test-45510-deg-{int(perf_counter_ns())}'
             resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                         log_prefix=self.test_prefix_deg,
                                                         skipcleanup=True, setup_s3bench=False)
         else:
+            LOGGER.info("Step 4: Create new objects and perform WRITEs/READs/Verify with variable "
+                        "object sizes in degraded mode")
             resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                         log_prefix=self.test_prefix,
                                                         skipcleanup=True, setup_s3bench=False)
@@ -484,26 +484,32 @@ class TestDataServerPodRestart:
         LOGGER.info("Step 5: Successfully started data and server pod and cluster is online.")
         self.restore_pod = False
         if CMN_CFG["dtm0_disabled"]:
-            LOGGER.info("Step 6: Perform READs and verify DI on the data written in degraded mode")
+            LOGGER.info("Step 6: Perform READs and verify DI on the data written on buckets "
+                        "created in degraded mode")
             resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                         log_prefix=self.test_prefix_deg,
                                                         skipwrite=True, skipcleanup=True,
                                                         setup_s3bench=False)
             assert_utils.assert_true(resp[0], resp[1])
-            LOGGER.info("Step 6: Successfully run READ/Verify on data written in degraded mode")
-        LOGGER.info("Step 7: Perform READ/Verify on data written in healthy mode")
+            LOGGER.info("Step 6: Successfully run READ/Verify on data written on buckets created "
+                        "in degraded mode")
+        LOGGER.info("Step 7: Perform READ/Verify on data written with buckets created in healthy "
+                    "mode")
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                     log_prefix=self.test_prefix, skipwrite=True,
                                                     skipcleanup=True, setup_s3bench=False)
         assert_utils.assert_true(resp[0], resp[1])
-        LOGGER.info("Step 7: Successfully run READ/Verify on data written in healthy mode")
-        LOGGER.info("Step 8: Create new IAM user and buckets, Perform WRITEs-READs-Verify with "
-                    "variable object sizes after data and server pod restart")
+        LOGGER.info("Step 7: Successfully run READ/Verify on data written with buckets created in "
+                    "healthy mode")
         if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("Step 8: Create new IAM user and buckets, Perform WRITEs-READs-Verify with "
+                        "variable object sizes after data and server pod restart")
             users = self.mgnt_ops.create_account_users(nusers=1)
-            t_t = str(perf_counter_ns())
-            self.test_prefix = f'test-45510-restart-{t_t}'
+            self.test_prefix = f'test-45510-restart-{int(perf_counter_ns())}'
             self.s3_clean.update(users)
+        else:
+            LOGGER.info("Step 8: Create new objects, Perform WRITEs-READs-Verify with variable "
+                        "object sizes after data and server pod restart")
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                     log_prefix=self.test_prefix,
                                                     skipcleanup=True, setup_s3bench=False)


### PR DESCRIPTION
Signed-off-by: RAHUL HATWAR <rahulchandrakant.hatwar@seagate.com>

# Problem Statement
Data server pod restart - Test-45510

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide

Collection logs : 

ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_object_versioned_bucket_32731', 'test_id': 'TEST-32731', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_object_versioned_bucket_32729', 'test_id': 'TEST-32729', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[None]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Enabled]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Suspended]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_preexist_mpu_versioning_enabled_bkt_41284', 'test_id': 'TEST-41284', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_ver_enabled_bkt_41285', 'test_id': 'TEST-41285', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_versioning_suspended_bkt_41286', 'test_id': 'TEST-41286', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_del_versioning_enabled_bkt_41287', 'test_id': 'TEST-41287', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_abort_multipart_upload_does_not_create_a_new_version_41288', 'test_id': 'TEST-41288', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_upload_multiple_versions_to_multipart_uploaded_object_in_versioned_bucket_41289', 'test_id': 'TEST-41289', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_upload_new_versions_to_existing_objects_using_multipart_upload_41290', 'test_id': 'TEST-41290', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_preexisting_32724', 'test_id': 'TEST-32724', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_enabled_32728', 'test_id': 'TEST-32728', 'marks': ['s3_ops', 'sanity']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_suspended_32733', 'test_id': 'TEST-32733', 'marks': ['s3_ops']}, {'nodeid': 'tests/security/test_cortx_port_scanner_kubectl_svc.py::test_cortx_port_scanner_kubectl_svc', 'test_id': 'TEST-34217', 'marks': ['security']}, {'nodeid': 'tests/security/test_cortx_port_scanner_netstat.py::test_cortx_port_scanner_netstat', 'test_id': 'TEST-34218', 'marks': ['security']}] created at /root/rahul_workspace/cortx-test-1/log/te_meta.json
Successfully unmounted directory

=========================================== 2418 tests collected in 5.31s ============================================