### PR TITLE
Cortx 33333 part2

### DIFF
--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -670,21 +670,20 @@ class TestDataServerPodRestart:
         LOGGER.info("Waiting for background IOs thread to join")
         thread_wri.join()
         thread_rd.join()
-        if CMN_CFG["dtm0_disabled"]:
-            thread_del.join()
-            LOGGER.info("Step 6.1: Verify status for In-flight DELETEs")
-            del_resp = tuple()
-            while len(del_resp) != 2:
-                del_resp = del_output.get(timeout=HA_CFG["common_params"]["60sec_delay"])
-            if not del_resp:
-                assert_utils.assert_true(False, "Background process failed to do deletes")
-            event_del_bkt = del_resp[0]
-            fail_del_bkt = del_resp[1]
-            assert_utils.assert_false(len(fail_del_bkt) or len(event_del_bkt),
-                                      "Expected all pass, Buckets which failed in DELETEs before "
-                                      f"and after pod deletion: {fail_del_bkt}. Buckets which "
-                                      f"failed in DELETEs during pod deletion: {event_del_bkt}.")
-            LOGGER.info("Step 6.1: Verified status for In-flight DELETEs")
+        thread_del.join()
+        LOGGER.info("Step 6.1: Verify status for In-flight DELETEs")
+        del_resp = tuple()
+        while len(del_resp) != 2:
+            del_resp = del_output.get(timeout=HA_CFG["common_params"]["60sec_delay"])
+        if not del_resp:
+            assert_utils.assert_true(False, "Background process failed to do deletes")
+        event_del_bkt = del_resp[0]
+        fail_del_bkt = del_resp[1]
+        assert_utils.assert_false(len(fail_del_bkt) or len(event_del_bkt),
+                                  "Expected all pass, Buckets which failed in DELETEs before "
+                                  f"and after pod deletion: {fail_del_bkt}. Buckets which "
+                                  f"failed in DELETEs during pod deletion: {event_del_bkt}.")
+        LOGGER.info("Step 6.1: Verified status for In-flight DELETEs")
         LOGGER.info("Step 6.2: Verify status for In-flight WRITEs")
         responses_wr = dict()
         while len(responses_wr) != 2:

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -681,9 +681,9 @@ class TestDataServerPodRestart:
             event_del_bkt = del_resp[0]
             fail_del_bkt = del_resp[1]
             assert_utils.assert_false(len(fail_del_bkt) or len(event_del_bkt),
-                                      "Expected all pass, Buckets which failed in DELETEs before and "
-                                      f"after pod deletion: {fail_del_bkt}. Buckets which failed in "
-                                      f"DELETEs during pod deletion: {event_del_bkt}.")
+                                      "Expected all pass, Buckets which failed in DELETEs before "
+                                      f"and after pod deletion: {fail_del_bkt}. Buckets which "
+                                      f"failed in DELETEs during pod deletion: {event_del_bkt}.")
             LOGGER.info("Step 6.1: Verified status for In-flight DELETEs")
         LOGGER.info("Step 6.2: Verify status for In-flight WRITEs")
         responses_wr = dict()

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -599,7 +599,7 @@ class TestDataServerPodRestart:
                     "buckets for parallel DELETEs.", wr_bucket)
         LOGGER.info("Step 3.2: Perform WRITEs with variable object sizes for parallel READs")
         test_prefix_read = f'test-45517-read-{int(perf_counter_ns())}'
-        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users_org.values())[0],
                                                     log_prefix=test_prefix_read, skipread=True,
                                                     skipcleanup=True, nclients=5, nsamples=5,
                                                     setup_s3bench=False)
@@ -622,7 +622,7 @@ class TestDataServerPodRestart:
         LOGGER.info("Step 4.2: Perform WRITEs with variable object sizes in background")
         test_prefix_write = f'test-45517-write-{int(perf_counter_ns())}'
         output_wr = Queue()
-        args = {'s3userinfo': list(users.values())[0], 'log_prefix': test_prefix_write,
+        args = {'s3userinfo': list(users_org.values())[0], 'log_prefix': test_prefix_write,
                 'nclients': 1, 'nsamples': 5, 'skipread': True, 'skipcleanup': True,
                 'output': output_wr, 'setup_s3bench': False}
         thread_wri = threading.Thread(target=self.ha_obj.event_s3_operation, args=(event,),
@@ -633,7 +633,7 @@ class TestDataServerPodRestart:
                     "background")
         LOGGER.info("Step 4.3: Perform READs and verify DI on the written data in background")
         output_rd = Queue()
-        args = {'s3userinfo': list(users.values())[0], 'log_prefix': test_prefix_read,
+        args = {'s3userinfo': list(users_org.values())[0], 'log_prefix': test_prefix_read,
                 'nclients': 1, 'nsamples': 5, 'skipwrite': True, 'skipcleanup': True,
                 'output': output_rd, 'setup_s3bench': False}
         thread_rd = threading.Thread(target=self.ha_obj.event_s3_operation, args=(event,),

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -582,7 +582,7 @@ class TestDataServerPodRestart:
         self.s3_clean.update(users)
         access_key = list(users.values())[0]['accesskey']
         secret_key = list(users.values())[0]['secretkey']
-        test_prefix_del = f'test-delete-45517-{int(perf_counter_ns())}'
+        test_prefix_del = f'test-45517-delete-{int(perf_counter_ns())}'
         s3_test_obj = S3TestLib(access_key=access_key, secret_key=secret_key,
                                 endpoint_url=S3_CFG["s3_url"])
         LOGGER.info("Create %s buckets and put variable size objects.", wr_bucket)
@@ -600,7 +600,7 @@ class TestDataServerPodRestart:
         LOGGER.info("Step 3.1: Successfully performed WRITEs with variable object sizes on %s "
                     "buckets for parallel DELETEs.", wr_bucket)
         LOGGER.info("Step 3.2: Perform WRITEs with variable object sizes for parallel READs")
-        test_prefix_read = f'test-read-45517-{int(perf_counter_ns())}'
+        test_prefix_read = f'test-45517-read-{int(perf_counter_ns())}'
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
                                                     log_prefix=test_prefix_read, skipread=True,
                                                     skipcleanup=True, nclients=5, nsamples=5,
@@ -622,7 +622,7 @@ class TestDataServerPodRestart:
         LOGGER.info("Step 4.1: Successfully started DELETEs in background for %s buckets",
                     del_bucket)
         LOGGER.info("Step 4.2: Perform WRITEs with variable object sizes in background")
-        test_prefix_write = f'test-write-45517-{int(perf_counter_ns())}'
+        test_prefix_write = f'test-45517-write-{int(perf_counter_ns())}'
         output_wr = Queue()
         args = {'s3userinfo': list(users.values())[0], 'log_prefix': test_prefix_write,
                 'nclients': 1, 'nsamples': 5, 'skipread': True, 'skipcleanup': True,

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -535,6 +535,7 @@ class TestDataServerPodRestart:
         LOGGER.info("COMPLETED: Verify IO when any 1 data pod and any 1 server pod restart by "
                     "replica method")
 
+    # pylint: disable=too-many-locals
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-45517")
@@ -566,8 +567,7 @@ class TestDataServerPodRestart:
             self.pod_dict[pod_prefix].append(resp[1][pod_name]['method'])
             assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
             LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
-        self.restore_pod = True
-        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+            self.restore_pod = True
         LOGGER.info("Step 2: Successfully shutdown one data and one server pod. Verified cluster "
                     "and services states are as expected & remaining pods status is online")
         event = threading.Event()  # Event to be used to send when pod restart start
@@ -616,7 +616,6 @@ class TestDataServerPodRestart:
         thread_del = threading.Thread(target=self.ha_obj.put_get_delete,
                                       args=(event, s3_test_obj,), kwargs=args)
         thread_del.daemon = True  # Daemonize thread
-        thread_del.start()
         LOGGER.info("Step 4.1: Successfully started DELETEs in background for %s buckets",
                     del_bucket)
         LOGGER.info("Step 4.2: Perform WRITEs with variable object sizes in background")
@@ -628,7 +627,6 @@ class TestDataServerPodRestart:
         thread_wri = threading.Thread(target=self.ha_obj.event_s3_operation, args=(event,),
                                       kwargs=args)
         thread_wri.daemon = True  # Daemonize thread
-        thread_wri.start()
         LOGGER.info("Step 4.2: Successfully started WRITEs with variable sizes objects in "
                     "background")
         LOGGER.info("Step 4.3: Perform READs and verify DI on the written data in background")
@@ -640,6 +638,8 @@ class TestDataServerPodRestart:
                                      kwargs=args)
         thread_rd.daemon = True  # Daemonize thread
         thread_rd.start()
+        thread_wri.start()
+        thread_del.start()
         LOGGER.info("Step 4.3: Successfully started READs and verify on the written data in "
                     "background")
         LOGGER.info("Step 4: Successfully starting three independent background threads for READs,"

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -538,7 +538,6 @@ class TestDataServerPodRestart:
     # pylint: disable=too-many-locals
     @pytest.mark.ha
     @pytest.mark.lc
-    @pytest.mark.skip(reason="Bucket CRUDs not supported with DTM0Int0")
     @pytest.mark.tags("TEST-45517")
     def test_cont_io_data_server_pod_restart(self):
         """

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -23,8 +23,11 @@ HA test suite for single data and server Pod restart
 """
 
 import logging
+import os
 import secrets
+import threading
 import time
+from multiprocessing import Queue
 import re
 from time import perf_counter_ns
 
@@ -34,12 +37,16 @@ from commons import commands as cmd
 from commons import constants as const
 from commons.helpers.health_helper import Health
 from commons.helpers.pods_helper import LogicalNode
+from commons.params import TEST_DATA_FOLDER
 from commons.utils import assert_utils
 from commons.utils import system_utils as sysutils
 from config import CMN_CFG
+from config import HA_CFG
+from config.s3 import S3_CFG
 from libs.di.di_mgmt_ops import ManagementOPs
 from libs.ha.ha_common_libs_k8s import HAK8s
 from libs.s3.s3_rest_cli_interface_lib import S3AccountOperations
+from libs.s3.s3_test_lib import S3TestLib
 
 # Global Constants
 LOGGER = logging.getLogger(__name__)
@@ -87,6 +94,7 @@ class TestDataServerPodRestart:
                                                         password=cls.password[node]))
 
         cls.rest_obj = S3AccountOperations()
+        cls.test_dir_path = os.path.join(TEST_DATA_FOLDER, "HATestMultipartUpload")
 
     def setup_method(self):
         """
@@ -99,6 +107,9 @@ class TestDataServerPodRestart:
         self.s3_clean = dict()
         self.restore_pod = self.restore_method = self.deployment_name = self.set_name = None
         self.deployment_backup = None
+        if not os.path.exists(self.test_dir_path):
+            resp = sysutils.make_dirs(self.test_dir_path)
+            LOGGER.info("Created path: %s", resp)
         self.s3acc_name = f"ha_s3acc_{int(perf_counter_ns())}"
         self.s3acc_email = f"{self.s3acc_name}@seagate.com"
         LOGGER.info("Precondition: Verify cluster is up and running and all pods are online.")
@@ -167,6 +178,11 @@ class TestDataServerPodRestart:
         LOGGER.info("Cleanup: Check cluster status and start it if not up.")
         resp = self.ha_obj.poll_cluster_status(self.node_master_list[0])
         assert_utils.assert_true(resp[0], resp)
+        for file in self.extra_files:
+            if os.path.exists(file):
+                sysutils.remove_file(file)
+        LOGGER.info("Removing all files from %s", self.test_dir_path)
+        sysutils.cleanup_dir(self.test_dir_path)
         LOGGER.info("Done: Teardown completed.")
 
     # pylint: disable=too-many-statements
@@ -518,3 +534,194 @@ class TestDataServerPodRestart:
                     "data and server pod restart")
         LOGGER.info("COMPLETED: Verify IO when any 1 data pod and any 1 server pod restart by "
                     "replica method")
+
+    @pytest.mark.ha
+    @pytest.mark.lc
+    @pytest.mark.tags("TEST-45517")
+    def test_cont_io_data_server_pod_restart(self):
+        """
+        Verify Continuous IO when any 1 data pod and any 1 server pod restart by replica method
+        """
+        LOGGER.info("STARTED: Verify Continuous IO when any 1 data pod and any 1 server pod"
+                    " restart by replica method")
+        LOGGER.info("STEP 1: Perform WRITEs/READs/Verify with variable object sizes")
+        users_org = self.mgnt_ops.create_account_users(nusers=1)
+        self.test_prefix = f'test-45517-{int(perf_counter_ns())}'
+        self.s3_clean.update(users_org)
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users_org.values())[0],
+                                                    log_prefix=self.test_prefix, skipcleanup=True)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 1: Performed WRITEs/READs/Verify with variable sizes objects.")
+        LOGGER.info("Step 2: Shutdown one data and one server pod with replica method and verify "
+                    "cluster & remaining pods status")
+        for pod_prefix in self.pod_dict:
+            num_replica = self.pod_dict[pod_prefix][-1] - 1
+            resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+                master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+                pod_prefix=[pod_prefix], delete_pod=[self.pod_dict.get(pod_prefix)[0]],
+                num_replica=num_replica)
+            assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+            pod_name = list(resp[1].keys())[0]
+            self.pod_dict[pod_prefix].append(resp[1][pod_name]['deployment_name'])
+            self.pod_dict[pod_prefix].append(resp[1][pod_name]['method'])
+            assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+            LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("Step 2: Successfully shutdown one data and one server pod. Verified cluster "
+                    "and services states are as expected & remaining pods status is online")
+        event = threading.Event()  # Event to be used to send when pod restart start
+        wr_bucket = HA_CFG["s3_bucket_data"]["no_buckets_for_deg_deletes"]
+        LOGGER.info("Step 3.1: Perform WRITEs with variable object sizes on %s buckets "
+                    "for parallel DELETEs.", wr_bucket)
+        wr_output = Queue()
+        del_output = Queue()
+        remaining_bkt = HA_CFG["s3_bucket_data"]["no_bck_writes"]
+        del_bucket = wr_bucket - remaining_bkt
+        users = self.mgnt_ops.create_account_users(nusers=1)
+        self.s3_clean.update(users)
+        access_key = list(users.values())[0]['accesskey']
+        secret_key = list(users.values())[0]['secretkey']
+        test_prefix_del = f'test-delete-45517-{int(perf_counter_ns())}'
+        s3_test_obj = S3TestLib(access_key=access_key, secret_key=secret_key,
+                                endpoint_url=S3_CFG["s3_url"])
+        LOGGER.info("Create %s buckets and put variable size objects.", wr_bucket)
+        args = {'test_prefix': test_prefix_del, 'test_dir_path': self.test_dir_path,
+                'skipget': True, 'skipdel': True, 'bkts_to_wr': wr_bucket, 'output': wr_output}
+        self.ha_obj.put_get_delete(event, s3_test_obj, **args)
+        wr_resp = tuple()
+        while len(wr_resp) != 3:
+            wr_resp = wr_output.get(timeout=HA_CFG["common_params"]["60sec_delay"])
+        buckets = s3_test_obj.bucket_list()[1]
+        assert_utils.assert_equal(len(buckets), wr_bucket, f"Failed to create {wr_bucket} number "
+                                                           f"of buckets. Created {len(buckets)} "
+                                                           "number of buckets")
+        s3_data = wr_resp[0]
+        LOGGER.info("Step 3.1: Successfully performed WRITEs with variable object sizes on %s "
+                    "buckets for parallel DELETEs.", wr_bucket)
+        LOGGER.info("Step 3.2: Perform WRITEs with variable object sizes for parallel READs")
+        test_prefix_read = f'test-read-45517-{int(perf_counter_ns())}'
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=test_prefix_read, skipread=True,
+                                                    skipcleanup=True, nclients=5, nsamples=5,
+                                                    setup_s3bench=False)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 3.2: Performed WRITEs with variable sizes objects for parallel READs.")
+        LOGGER.info("Step 4: Starting three independent background threads for READs, WRITEs & "
+                    "DELETEs.")
+        LOGGER.info("Step 4.1: Start continuous DELETEs in background on random %s buckets",
+                    del_bucket)
+        bucket_list = s3_data.keys()
+        get_random_buck = self.system_random.sample(bucket_list, del_bucket)
+        args = {'test_prefix': test_prefix_del, 'test_dir_path': self.test_dir_path,
+                'skipput': True, 'skipget': True, 'bkt_list': get_random_buck, 'output': del_output}
+        thread_del = threading.Thread(target=self.ha_obj.put_get_delete,
+                                      args=(event, s3_test_obj,), kwargs=args)
+        thread_del.daemon = True  # Daemonize thread
+        thread_del.start()
+        LOGGER.info("Step 4.1: Successfully started DELETEs in background for %s buckets",
+                    del_bucket)
+        LOGGER.info("Step 4.2: Perform WRITEs with variable object sizes in background")
+        test_prefix_write = f'test-write-45517-{int(perf_counter_ns())}'
+        output_wr = Queue()
+        args = {'s3userinfo': list(users.values())[0], 'log_prefix': test_prefix_write,
+                'nclients': 1, 'nsamples': 5, 'skipread': True, 'skipcleanup': True,
+                'output': output_wr, 'setup_s3bench': False}
+        thread_wri = threading.Thread(target=self.ha_obj.event_s3_operation, args=(event,),
+                                      kwargs=args)
+        thread_wri.daemon = True  # Daemonize thread
+        thread_wri.start()
+        LOGGER.info("Step 4.2: Successfully started WRITEs with variable sizes objects in "
+                    "background")
+        LOGGER.info("Step 4.3: Perform READs and verify DI on the written data in background")
+        output_rd = Queue()
+        args = {'s3userinfo': list(users.values())[0], 'log_prefix': test_prefix_read,
+                'nclients': 1, 'nsamples': 5, 'skipwrite': True, 'skipcleanup': True,
+                'output': output_rd, 'setup_s3bench': False}
+        thread_rd = threading.Thread(target=self.ha_obj.event_s3_operation, args=(event,),
+                                     kwargs=args)
+        thread_rd.daemon = True  # Daemonize thread
+        thread_rd.start()
+        LOGGER.info("Step 4.3: Successfully started READs and verify on the written data in "
+                    "background")
+        LOGGER.info("Step 4: Successfully starting three independent background threads for READs,"
+                    " WRITEs & DELETEs.")
+        LOGGER.info("Wait for %s seconds for all background operations to start",
+                    HA_CFG["common_params"]["30sec_delay"])
+        time.sleep(HA_CFG["common_params"]["30sec_delay"])
+        LOGGER.info("Step 5: Restore data and server pod and check cluster status.")
+        event.set()
+        for pod_prefix in self.pod_dict:
+            self.restore_method = self.pod_dict.get(pod_prefix)[-1]
+            resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
+                                           restore_method=self.restore_method,
+                                           restore_params={
+                                               "deployment_name": self.pod_dict.get(pod_prefix)[-2],
+                                               "deployment_backup": self.deployment_backup,
+                                               "num_replica": self.pod_dict.get(pod_prefix)[2],
+                                               "set_name": self.pod_dict.get(pod_prefix)[1]},
+                                           clstr_status=True)
+            LOGGER.debug("Response: %s", resp)
+            assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method} way")
+            LOGGER.info("Successfully restored pod by %s way", self.restore_method)
+        LOGGER.info("Step 5: Successfully started data and server pod and cluster is online.")
+        self.restore_pod = False
+        event.clear()
+        LOGGER.info("Step 6: Verify status for In-flight READs/WRITEs/DELETEs while data and "
+                    "server pod was restarted")
+        LOGGER.info("Waiting for background IOs thread to join")
+        thread_wri.join()
+        thread_rd.join()
+        thread_del.join()
+        LOGGER.info("Step 6.1: Verify status for In-flight DELETEs")
+        del_resp = tuple()
+        while len(del_resp) != 2:
+            del_resp = del_output.get(timeout=HA_CFG["common_params"]["60sec_delay"])
+        if not del_resp:
+            assert_utils.assert_true(False, "Background process failed to do deletes")
+        event_del_bkt = del_resp[0]
+        fail_del_bkt = del_resp[1]
+        assert_utils.assert_false(len(fail_del_bkt) or len(event_del_bkt),
+                                  "Expected all pass, Buckets which failed in DELETEs before and "
+                                  f"after pod deletion: {fail_del_bkt}. Buckets which failed in "
+                                  f"DELETEs during pod deletion: {event_del_bkt}.")
+        LOGGER.info("Step 6.1: Verified status for In-flight DELETEs")
+        LOGGER.info("Step 6.2: Verify status for In-flight WRITEs")
+        responses_wr = dict()
+        while len(responses_wr) != 2:
+            responses_wr = output_wr.get(timeout=HA_CFG["common_params"]["60sec_delay"])
+        pass_logs = list(x[1] for x in responses_wr["pass_res"])
+        fail_logs = list(x[1] for x in responses_wr["fail_res"])
+        resp = self.ha_obj.check_s3bench_log(file_paths=pass_logs)
+        assert_utils.assert_false(len(resp[1]), "WRITEs before and after pod deletion are "
+                                                "expected to pass.Logs which contain failures:"
+                                                f"{resp[1]}")
+        resp = self.ha_obj.check_s3bench_log(file_paths=fail_logs)
+        assert_utils.assert_false(len(resp[1]), "In-flight WRITEs Logs which contain failures: "
+                                                f"{resp[1]}")
+        LOGGER.info("Step 6.2: Verified status for In-flight WRITEs")
+        LOGGER.info("Step 6.3: Verify status for In-flight READs/Verify DI")
+        responses_rd = dict()
+        while len(responses_rd) != 2:
+            responses_rd = output_rd.get(timeout=HA_CFG["common_params"]["60sec_delay"])
+        pass_logs = list(x[1] for x in responses_rd["pass_res"])
+        fail_logs = list(x[1] for x in responses_rd["fail_res"])
+        resp = self.ha_obj.check_s3bench_log(file_paths=pass_logs)
+        assert_utils.assert_false(len(resp[1]), "READs/VerifyDI logs which contain failures:"
+                                                f"{resp[1]}")
+        resp = self.ha_obj.check_s3bench_log(file_paths=fail_logs)
+        assert_utils.assert_false(len(resp[1]), "READs/VerifyDI Logs which contain failures: "
+                                                f"{resp[1]}")
+        LOGGER.info("Step 6.3: Verified status for In-flight READs/Verify DI")
+        LOGGER.info("Step 6: Verified status for In-flight READs/WRITEs/DELETEs while data and "
+                    "server pod was restarted")
+        LOGGER.info("Step 7: Verify READ/Verify for data written in healthy cluster and delete "
+                    "buckets")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users_org.values())[0],
+                                                    log_prefix=self.test_prefix, skipwrite=True,
+                                                    setup_s3bench=False)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 7: Verified READ/Verify on data written in healthy mode and deleted "
+                    "buckets")
+        LOGGER.info("COMPLETED: Verify Continuous IO when any 1 data pod and any 1 server pod"
+                    " restart by replica method")

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -578,10 +578,8 @@ class TestDataServerPodRestart:
         del_output = Queue()
         remaining_bkt = HA_CFG["s3_bucket_data"]["no_bck_writes"]
         del_bucket = wr_bucket - remaining_bkt
-        users = self.mgnt_ops.create_account_users(nusers=1)
-        self.s3_clean.update(users)
-        access_key = list(users.values())[0]['accesskey']
-        secret_key = list(users.values())[0]['secretkey']
+        access_key = list(users_org.values())[0]['accesskey']
+        secret_key = list(users_org.values())[0]['secretkey']
         test_prefix_del = f'test-45517-delete-{int(perf_counter_ns())}'
         s3_test_obj = S3TestLib(access_key=access_key, secret_key=secret_key,
                                 endpoint_url=S3_CFG["s3_url"])

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
@@ -303,7 +303,8 @@ class TestDataServerPodRestartAPI:
                                                        obj_download_path=download_path)
             LOGGER.info("Download object response: %s", resp)
             assert_utils.assert_true(resp[0], resp[1])
-            dnld_chksm = self.ha_obj.cal_compare_checksum(file_list=[download_path], compare=False)[0]
+            dnld_chksm = self.ha_obj.cal_compare_checksum(file_list=[download_path],
+                                                          compare=False)[0]
             assert_utils.assert_equal(bkt_obj_dict[bkt_obj][-1], dnld_chksm,
                                       f"Expected checksum: {upld_chksm_hlt},"
                                       f"Actual checksum: {dnld_chksm}")

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
@@ -271,7 +271,8 @@ class TestDataServerPodRestartAPI:
                                                "deployment_name": self.pod_dict.get(pod_prefix)[-2],
                                                "deployment_backup": self.deployment_backup,
                                                "num_replica": self.pod_dict.get(pod_prefix)[2],
-                                               "set_name": self.pod_dict.get(pod_prefix)[1]})
+                                               "set_name": self.pod_dict.get(pod_prefix)[1]},
+                                           clstr_status=True)
             LOGGER.debug("Response: %s", resp)
             assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method} way")
             LOGGER.info("Successfully restored pod by %s way", self.restore_method)

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
@@ -174,6 +174,8 @@ class TestDataServerPodRestartAPI:
         system_utils.cleanup_dir(self.test_dir_path)
         LOGGER.info("Done: Teardown completed.")
 
+    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-statements
     @pytest.mark.ha
     @pytest.mark.lc
     @pytest.mark.tags("TEST-45534")
@@ -188,6 +190,10 @@ class TestDataServerPodRestartAPI:
         chunk_obj_path = os.path.join(self.test_dir_path, self.object_name)
         upload_op = Queue()
         workload_info = dict()
+        t_t = int(perf_counter_ns())
+        bucket_name = f"chunk-upload-bkt-{t_t}"
+        object_name = f"chunk-upload-obj-{t_t}"
+        chunk_obj_path = os.path.join(self.test_dir_path, object_name)
         LOGGER.info("Step 1: Perform setup steps for jclient")
         jc_obj = JCloudClient()
         resp = self.ha_obj.setup_jclient(jc_obj)
@@ -230,8 +236,7 @@ class TestDataServerPodRestartAPI:
             self.pod_dict[pod_prefix].append(resp[1][pod_name]['method'])
             assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
             LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
-        self.restore_pod = True
-        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+            self.restore_pod = True
         LOGGER.info("Step 3: Successfully shutdown one data and one server pod. Verified cluster "
                     "and services states are as expected & remaining pods status is online")
         LOGGER.info("Step 4: Download object which was uploaded in healthy cluster and verify "
@@ -249,10 +254,6 @@ class TestDataServerPodRestartAPI:
                                   f"Actual checksum: {dnld_chksm}")
         LOGGER.info("Step 4: Successfully downloaded object which was uploaded in healthy cluster "
                     "and verified checksum")
-        t_t = int(perf_counter_ns())
-        bucket_name = f"chunk-upload-bkt-{t_t}"
-        object_name = f"chunk-upload-obj-{t_t}"
-        chunk_obj_path = os.path.join(self.test_dir_path, object_name)
         LOGGER.info("Step 5: Start chunk upload in background")
         args = {'s3_data': self.s3_clean, 'bucket_name': bucket_name,
                 'file_size': file_size, 'chunk_obj_path': chunk_obj_path, 'output': upload_op}

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
@@ -1,0 +1,319 @@
+#!/usr/bin/python  # pylint: disable=too-many-instance-attributes
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+"""
+HA test suite for Data and server pod restart
+"""
+
+import logging
+import os
+import re
+import secrets
+import threading
+import time
+from multiprocessing import Queue
+from time import perf_counter_ns
+
+import pytest
+
+from commons import constants as const
+from commons.helpers.health_helper import Health
+from commons.helpers.pods_helper import LogicalNode
+from commons.params import TEST_DATA_FOLDER
+from commons.utils import assert_utils
+from commons.utils import system_utils
+from config import CMN_CFG
+from config import HA_CFG
+from config.s3 import S3_CFG
+from libs.ha.ha_common_libs_k8s import HAK8s
+from libs.s3.s3_blackbox_test_lib import JCloudClient
+from libs.s3.s3_rest_cli_interface_lib import S3AccountOperations
+
+# Global Constants
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-many-lines
+# pylint: disable=too-many-public-methods
+class TestDataServerPodRestartAPI:
+    """
+    Test suite for Data and server pod restart
+    """
+    @classmethod
+    def setup_class(cls):
+        """
+        Setup operations for the test file.
+        """
+        LOGGER.info("STARTED: Setup Module operations.")
+        cls.num_nodes = len(CMN_CFG["nodes"])
+        cls.username = list()
+        cls.password = list()
+        cls.node_master_list = list()
+        cls.hlth_master_list = list()
+        cls.node_worker_list = list()
+        cls.ha_obj = HAK8s()
+        cls.random_time = cls.s3_clean = cls.test_prefix = None
+        cls.s3acc_name = cls.s3acc_email = cls.bucket_name = cls.object_name = None
+        cls.system_random = secrets.SystemRandom()
+
+        for node in range(cls.num_nodes):
+            cls.host = CMN_CFG["nodes"][node]["hostname"]
+            cls.username.append(CMN_CFG["nodes"][node]["username"])
+            cls.password.append(CMN_CFG["nodes"][node]["password"])
+            if CMN_CFG["nodes"][node]["node_type"] == "master":
+                cls.node_master_list.append(LogicalNode(hostname=cls.host,
+                                                        username=cls.username[node],
+                                                        password=cls.password[node]))
+                cls.hlth_master_list.append(Health(hostname=cls.host,
+                                                   username=cls.username[node],
+                                                   password=cls.password[node]))
+            else:
+                cls.node_worker_list.append(LogicalNode(hostname=cls.host,
+                                                        username=cls.username[node],
+                                                        password=cls.password[node]))
+
+        cls.rest_obj = S3AccountOperations()
+        cls.test_file = "ha_mp_obj"
+        cls.test_dir_path = os.path.join(TEST_DATA_FOLDER, "HATestMultipartUpload")
+
+    def setup_method(self):
+        """
+        This function will be invoked prior to each test case.
+        """
+        LOGGER.info("STARTED: Setup Operations")
+        self.random_time = int(time.time())
+        self.s3_clean = dict()
+        self.restore_pod = self.restore_method = self.deployment_name = self.set_name = None
+        self.deployment_backup = None
+        if not os.path.exists(self.test_dir_path):
+            resp = system_utils.make_dirs(self.test_dir_path)
+            LOGGER.info("Created path: %s", resp)
+        self.s3acc_name = f"ha_s3acc_{int(perf_counter_ns())}"
+        self.s3acc_email = f"{self.s3acc_name}@seagate.com"
+        self.bucket_name = f"ha-mp-bkt-{int(perf_counter_ns())}"
+        self.object_name = f"ha-mp-obj-{int(perf_counter_ns())}"
+        self.extra_files = list()
+        LOGGER.info("Precondition: Verify cluster is up and running and all pods are online.")
+        resp = self.ha_obj.check_cluster_status(self.node_master_list[0])
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Precondition: Verified cluster is up and running and all pods are online.")
+        convert = lambda text: int(text) if text.isdigit() else text
+        alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
+        LOGGER.info("Get %s and %s pods to be deleted", const.POD_NAME_PREFIX,
+                    const.SERVER_POD_NAME_PREFIX)
+        self.pod_dict = dict()
+        for prefix in [const.POD_NAME_PREFIX, const.SERVER_POD_NAME_PREFIX]:
+            self.pod_list = list()
+            sts_dict = self.node_master_list[0].get_sts_pods(pod_prefix=prefix)
+            sts_list = list(sts_dict.keys())
+            LOGGER.debug("%s Statefulset: %s", prefix, sts_list)
+            sts = self.system_random.sample(sts_list, 1)[0]
+            sts_dict_val = sorted(sts_dict.get(sts), key=alphanum_key)
+            self.delete_pod = sts_dict_val[-1]
+            LOGGER.info("Pod to be deleted is %s", self.delete_pod)
+            self.set_type, self.set_name = self.node_master_list[0].get_set_type_name(
+                pod_name=self.delete_pod)
+            self.pod_list.append(self.delete_pod)
+            self.pod_list.append(self.set_name)
+            resp = self.node_master_list[0].get_num_replicas(self.set_type, self.set_name)
+            assert_utils.assert_true(resp[0], resp)
+            self.num_replica = int((resp[1]))
+            self.pod_list.append(self.num_replica)
+            self.pod_dict[prefix] = self.pod_list
+        LOGGER.info("COMPLETED: Setup operations. ")
+
+    def teardown_method(self):
+        """
+        This function will be invoked after each test function in the module.
+        """
+        LOGGER.info("STARTED: Teardown Operations.")
+        if self.restore_pod:
+            for pod_prefix in self.pod_dict:
+                self.restore_method = self.pod_dict.get(pod_prefix)[-1]
+                resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
+                                               restore_method=self.restore_method,
+                                               restore_params={
+                                                   "deployment_name":
+                                                       self.pod_dict.get(pod_prefix)[-2],
+                                                   "deployment_backup": self.deployment_backup,
+                                                   "num_replica": self.pod_dict.get(pod_prefix)[2],
+                                                   "set_name": self.pod_dict.get(pod_prefix)[1]})
+                LOGGER.debug("Response: %s", resp)
+                assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method}"
+                                                  " way")
+                LOGGER.info("Successfully restored pod by %s way", self.restore_method)
+        if self.s3_clean:
+            LOGGER.info("Cleanup: Cleaning created s3 accounts and buckets.")
+            resp = self.ha_obj.delete_s3_acc_buckets_objects(self.s3_clean)
+            assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Cleanup: Check cluster status and start it if not up.")
+        resp = self.ha_obj.poll_cluster_status(self.node_master_list[0])
+        assert_utils.assert_true(resp[0], resp)
+        LOGGER.info("Removing extra files")
+        for file in self.extra_files:
+            if os.path.exists(file):
+                system_utils.remove_file(file)
+        LOGGER.info("Removing all files from %s", self.test_dir_path)
+        system_utils.cleanup_dir(self.test_dir_path)
+        LOGGER.info("Done: Teardown completed.")
+
+    @pytest.mark.ha
+    @pytest.mark.lc
+    @pytest.mark.tags("TEST-45534")
+    def test_chunk_upload_during_data_server_pod_restart(self):
+        """
+        Verify chunk upload during 1 data pod and 1 server pod restart (using jclient)
+        """
+        LOGGER.info("STARTED: Verify chunk upload during 1 data pod and 1 server pod restart")
+
+        file_size = HA_CFG["5gb_mpu_data"]["file_size"]
+        download_path = os.path.join(self.test_dir_path, "test_chunk_upload" + "_download")
+        chunk_obj_path = os.path.join(self.test_dir_path, self.object_name)
+        upload_op = Queue()
+        workload_info = dict()
+        LOGGER.info("Step 1: Perform setup steps for jclient")
+        jc_obj = JCloudClient()
+        resp = self.ha_obj.setup_jclient(jc_obj)
+        assert_utils.assert_true(resp, "Failed in setting up jclient")
+        LOGGER.info("Step 1: Successfully setup jclient on runner")
+        LOGGER.info("Step 2: Create IAM user with name %s, bucket %s and perform chunk upload",
+                    self.s3acc_name, self.bucket_name)
+        resp = self.rest_obj.create_s3_account(acc_name=self.s3acc_name,
+                                               email_id=self.s3acc_email,
+                                               passwd=S3_CFG["CliConfig"]["s3_account"]["password"])
+        assert_utils.assert_true(resp[0], resp[1])
+        access_key = resp[1]["access_key"]
+        secret_key = resp[1]["secret_key"]
+        self.test_prefix = f'test-45534-{int(perf_counter_ns())}'
+        self.s3_clean = {'s3_acc': {'accesskey': access_key, 'secretkey': secret_key,
+                                    'user_name': self.s3acc_name}}
+        resp = self.ha_obj.create_bucket_chunk_upload(s3_data=self.s3_clean,
+                                                      bucket_name=self.bucket_name,
+                                                      file_size=file_size,
+                                                      chunk_obj_path=chunk_obj_path,
+                                                      background=False)
+        self.extra_files.append(chunk_obj_path)
+        assert_utils.assert_true(resp, "Failure observed in chunk upload in healthy cluster")
+        LOGGER.info("Step 2: Successfully performed chuck upload")
+        workload_info[1] = [self.bucket_name, self.object_name]
+        LOGGER.info("Calculating checksum of uploaded file %s", chunk_obj_path)
+        upld_chksm_hlt = self.ha_obj.cal_compare_checksum(file_list=[chunk_obj_path],
+                                                          compare=False)[0]
+        LOGGER.info("Step 3: Shutdown one data and one server pod with replica method and verify"
+                    " cluster & remaining pods status")
+        for pod_prefix in self.pod_dict:
+            num_replica = self.pod_dict[pod_prefix][-1] - 1
+            resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+                master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+                pod_prefix=[pod_prefix], delete_pod=[self.pod_dict.get(pod_prefix)[0]],
+                num_replica=num_replica)
+            assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+            pod_name = list(resp[1].keys())[0]
+            self.pod_dict[pod_prefix].append(resp[1][pod_name]['deployment_name'])
+            self.pod_dict[pod_prefix].append(resp[1][pod_name]['method'])
+            assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+            LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("Step 3: Successfully shutdown one data and one server pod. Verified cluster "
+                    "and services states are as expected & remaining pods status is online")
+        LOGGER.info("Step 4: Download object which was uploaded in healthy cluster and verify "
+                    "checksum")
+        resp = self.ha_obj.object_download_jclient(s3_data=self.s3_clean,
+                                                   bucket_name=self.bucket_name,
+                                                   object_name=self.object_name,
+                                                   obj_download_path=download_path)
+        LOGGER.info("Download object response: %s", resp)
+        self.extra_files.append(download_path)
+        assert_utils.assert_true(resp[0], resp[1])
+        dnld_chksm = self.ha_obj.cal_compare_checksum(file_list=[download_path], compare=False)[0]
+        assert_utils.assert_equal(upld_chksm_hlt, dnld_chksm,
+                                  f"Expected checksum: {upld_chksm_hlt},"
+                                  f"Actual checksum: {dnld_chksm}")
+        LOGGER.info("Step 4: Successfully downloaded object which was uploaded in healthy cluster "
+                    "and verified checksum")
+        t_t = int(perf_counter_ns())
+        bucket_name = f"chunk-upload-bkt-{t_t}"
+        object_name = f"chunk-upload-obj-{t_t}"
+        chunk_obj_path = os.path.join(self.test_dir_path, object_name)
+        LOGGER.info("Step 5: Start chunk upload in background")
+        args = {'s3_data': self.s3_clean, 'bucket_name': bucket_name,
+                'file_size': file_size, 'chunk_obj_path': chunk_obj_path, 'output': upload_op}
+        thread = threading.Thread(target=self.ha_obj.create_bucket_chunk_upload, kwargs=args)
+        thread.daemon = True  # Daemonize thread
+        thread.start()
+        LOGGER.info("Waiting for %s sec...", HA_CFG["common_params"]["30sec_delay"])
+        time.sleep(HA_CFG["common_params"]["30sec_delay"])
+        LOGGER.info("Step 5: Successfully started chuck upload in background")
+        LOGGER.info("Step 6: Restore data, server pod and check cluster status.")
+        for pod_prefix in self.pod_dict:
+            self.restore_method = self.pod_dict.get(pod_prefix)[-1]
+            resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
+                                           restore_method=self.restore_method,
+                                           restore_params={
+                                               "deployment_name": self.pod_dict.get(pod_prefix)[-2],
+                                               "deployment_backup": self.deployment_backup,
+                                               "num_replica": self.pod_dict.get(pod_prefix)[2],
+                                               "set_name": self.pod_dict.get(pod_prefix)[1]})
+            LOGGER.debug("Response: %s", resp)
+            assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method} way")
+            LOGGER.info("Successfully restored pod by %s way", self.restore_method)
+        LOGGER.info("Step 6: Successfully started data, server pod and cluster is online.")
+        self.restore_pod = False
+        LOGGER.info("Step 7: Verifying response of background chunk upload process")
+        self.extra_files.append(chunk_obj_path)
+        while True:
+            resp = upload_op.get(timeout=HA_CFG["common_params"]["60sec_delay"])
+            if isinstance(resp, bool):
+                break
+        if resp is None:
+            assert_utils.assert_true(False, "Background process of chunk upload failed")
+        assert_utils.assert_true(resp, "Failure observed in chunk upload during server pod restart")
+        LOGGER.info("Step 7: Successfully performed chuck upload during server pod restart")
+        LOGGER.info("Step 8: Download object which was uploaded in healthy cluster and verify "
+                    "checksum")
+        resp = self.ha_obj.object_download_jclient(s3_data=self.s3_clean,
+                                                   bucket_name=self.bucket_name,
+                                                   object_name=self.object_name,
+                                                   obj_download_path=download_path)
+        LOGGER.info("Download object response: %s", resp)
+        assert_utils.assert_true(resp[0], resp[1])
+        dnld_chksm = self.ha_obj.cal_compare_checksum(file_list=[download_path], compare=False)[0]
+        assert_utils.assert_equal(upld_chksm_hlt, dnld_chksm,
+                                  f"Expected checksum: {upld_chksm_hlt},"
+                                  f"Actual checksum: {dnld_chksm}")
+        LOGGER.info("Step 8: Successfully downloaded object and verified checksum")
+        LOGGER.info("Step 9: Download object which was uploaded in background and verify checksum")
+        LOGGER.info("Calculating checksum of uploaded file %s", chunk_obj_path)
+        upload_checksum = self.ha_obj.cal_compare_checksum(file_list=[chunk_obj_path],
+                                                           compare=False)[0]
+        resp = self.ha_obj.object_download_jclient(s3_data=self.s3_clean,
+                                                   bucket_name=bucket_name,
+                                                   object_name=object_name,
+                                                   obj_download_path=download_path)
+        LOGGER.info("Download object response: %s", resp)
+        assert_utils.assert_true(resp[0], resp[1])
+        download_checksum = self.ha_obj.cal_compare_checksum(file_list=[download_path],
+                                                             compare=False)[0]
+        assert_utils.assert_equal(upload_checksum, download_checksum,
+                                  f"Expected checksum: {upload_checksum},"
+                                  f"Actual checksum: {download_checksum}")
+        LOGGER.info("Step 9: Successfully downloaded object and verified checksum")
+        LOGGER.info("COMPLETED: Verify chunk upload during 1 data pod and 1 server pod restart")


### PR DESCRIPTION
Signed-off-by: RAHUL HATWAR <rahulchandrakant.hatwar@seagate.com>

# Problem Statement
Data Server pod restart - TEST-45534, 45517

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide
Collection Logs : 
VersioningGetHeadObject::test_get_head_object_preexisting_32739', 'test_id': 'TEST-32739', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_object_versioned_bucket_32731', 'test_id': 'TEST-32731', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_object_versioned_bucket_32729', 'test_id': 'TEST-32729', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[None]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Enabled]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Suspended]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_preexist_mpu_versioning_enabled_bkt_41284', 'test_id': 'TEST-41284', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_ver_enabled_bkt_41285', 'test_id': 'TEST-41285', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_versioning_suspended_bkt_41286', 'test_id': 'TEST-41286', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_del_versioning_enabled_bkt_41287', 'test_id': 'TEST-41287', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_abort_multipart_upload_does_not_create_a_new_version_41288', 'test_id': 'TEST-41288', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_upload_multiple_versions_to_multipart_uploaded_object_in_versioned_bucket_41289', 'test_id': 'TEST-41289', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_upload_new_versions_to_existing_objects_using_multipart_upload_41290', 'test_id': 'TEST-41290', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_preexisting_32724', 'test_id': 'TEST-32724', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_enabled_32728', 'test_id': 'TEST-32728', 'marks': ['s3_ops', 'sanity']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_suspended_32733', 'test_id': 'TEST-32733', 'marks': ['s3_ops']}, {'nodeid': 'tests/security/test_cortx_port_scanner_kubectl_svc.py::test_cortx_port_scanner_kubectl_svc', 'test_id': 'TEST-34217', 'marks': ['security']}, {'nodeid': 'tests/security/test_cortx_port_scanner_netstat.py::test_cortx_port_scanner_netstat', 'test_id': 'TEST-34218', 'marks': ['security']}] created at /root/rahul_workspace/cortx-test-1/log/te_meta.json
Successfully unmounted directory

=========================================== 2421 tests collected in 8.67s ============================================