### PR TITLE
Data and Server pod restart - TEST-45529, 45536

### DIFF
--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -759,7 +759,6 @@ class TestDataServerPodRestart:
         assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
         LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
         self.restore_pod = True
-        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
         LOGGER.info("Step 2: Successfully shutdown one data pod with replica method and verify "
                     "cluster & remaining pods status")
 
@@ -771,19 +770,15 @@ class TestDataServerPodRestart:
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("STEP 3: Performed READs/Verify on data written in healthy cluster in step-1")
 
+        self.test_prefix_deg = self.test_prefix
         if CMN_CFG["dtm0_disabled"]:
             LOGGER.info("STEP 4: Create new bucket and perform WRITEs/READs/Verify with variable "
                         "object sizes in degraded mode")
             self.test_prefix_deg = f'test-45529-deg-{int(perf_counter_ns())}'
-            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                        log_prefix=self.test_prefix_deg,
-                                                        skipcleanup=True, setup_s3bench=False,
-                                                        nsamples=5, nclients=5)
-            assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("STEP 4: Create new objects and perform WRITEs/READs/Verify with variable "
                     "object sizes in degraded mode")
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                    log_prefix=self.test_prefix,
+                                                    log_prefix=self.test_prefix_deg,
                                                     skipcleanup=True, setup_s3bench=False,
                                                     nsamples=5, nclients=5)
         assert_utils.assert_true(resp[0], resp[1])
@@ -816,6 +811,7 @@ class TestDataServerPodRestart:
         LOGGER.info("STEP 6: Successfully run READ/Verify on data written with buckets created in "
                     "healthy mode in step-1")
 
+        self.test_prefix_datapod_restart = self.test_prefix
         if CMN_CFG["dtm0_disabled"]:
             LOGGER.info("STEP 7: Perform READs and verify DI on the data written on buckets "
                         "created in degraded mode in step-4")
@@ -827,21 +823,15 @@ class TestDataServerPodRestart:
             LOGGER.info("STEP 7: Successfully run READ/Verify on data written on buckets created "
                         "in degraded mode in step-4")
 
-        if CMN_CFG["dtm0_disabled"]:
             LOGGER.info("STEP 8: Create new IAM user and buckets, Perform WRITEs-READs-Verify with "
                         "variable object sizes after data pod restart")
             users = self.mgnt_ops.create_account_users(nusers=1)
             self.test_prefix_datapod_restart = f'test-45510-restart-{int(perf_counter_ns())}'
             self.s3_clean.update(users)
-            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                        log_prefix=self.test_prefix_datapod_restart,
-                                                        skipcleanup=True, setup_s3bench=False,
-                                                        nsamples=5, nclients=5)
-            assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("STEP 8: Create new objects and perform WRITEs/READs/Verify with variable "
                     "object sizes after data pod restart")
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                    log_prefix=self.test_prefix,
+                                                    log_prefix=self.test_prefix_datapod_restart,
                                                     skipcleanup=True, setup_s3bench=False,
                                                     nsamples=5, nclients=5)
         assert_utils.assert_true(resp[0], resp[1])
@@ -863,7 +853,6 @@ class TestDataServerPodRestart:
         assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
         LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
         self.restore_pod = True
-        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
         LOGGER.info("STEP 9: Successfully shutdown one server pod with replica method and verify "
                     "cluster & remaining pods status")
 
@@ -889,7 +878,7 @@ class TestDataServerPodRestart:
             LOGGER.info("STEP 10.3: Perform READs/Verify on data written after data pod restart "
                         "in step-8")
             resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                        log_prefix=self.test_prefix_deg,
+                                                        log_prefix=self.test_prefix_datapod_restart,
                                                         skipwrite=True, skipcleanup=True,
                                                         setup_s3bench=False, nsamples=5, nclients=5)
             assert_utils.assert_true(resp[0], resp[1])
@@ -1022,7 +1011,6 @@ class TestDataServerPodRestart:
         assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
         LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
         self.restore_pod = True
-        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
         LOGGER.info("Step 2: Successfully shutdown one data pod with replica method and verify "
                     "cluster & remaining pods status")
 
@@ -1034,19 +1022,15 @@ class TestDataServerPodRestart:
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 3: Performed READs/Verify on data written in healthy cluster in step-1")
 
+        self.test_prefix_deg = self.test_prefix
         if CMN_CFG["dtm0_disabled"]:
             LOGGER.info("Step 4: Create new bucket and perform WRITEs/READs/Verify with variable "
                         "object sizes in degraded mode")
             self.test_prefix_deg = f'test-45536-deg-{int(perf_counter_ns())}'
-            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                        log_prefix=self.test_prefix_deg,
-                                                        skipcleanup=True, setup_s3bench=False,
-                                                        nsamples=5, nclients=5)
-            assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 4: Create new objects and perform WRITEs/READs/Verify with variable "
                     "object sizes in degraded mode")
         resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                    log_prefix=self.test_prefix,
+                                                    log_prefix=self.test_prefix_deg,
                                                     skipcleanup=True, setup_s3bench=False,
                                                     nsamples=5, nclients=5)
         assert_utils.assert_true(resp[0], resp[1])
@@ -1068,7 +1052,6 @@ class TestDataServerPodRestart:
         assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
         LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
         self.restore_pod = True
-        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
         LOGGER.info("Step 5: Successfully shutdown one server pod with replica method and verify "
                     "cluster & remaining pods status")
 
@@ -1105,10 +1088,9 @@ class TestDataServerPodRestart:
                     "step-7 in background")
         output_rd = Queue()
         event = threading.Event()
-        event_set_clr = [False]
         args = {'s3userinfo': list(users.values())[0], 'log_prefix': self.test_prefix,
                 'nclients': 5, 'nsamples': 5, 'skipwrite': True, 'skipcleanup': True,
-                'output': output_rd, 'setup_s3bench': False, 'event_set_clr': event_set_clr}
+                'output': output_rd, 'setup_s3bench': False}
         thread_rd = threading.Thread(target=self.ha_obj.event_s3_operation, args=(event,),
                                      kwargs=args)
         thread_rd.daemon = True  # Daemonize thread
@@ -1144,12 +1126,12 @@ class TestDataServerPodRestart:
             responses_rd = output_rd.get(timeout=HA_CFG["common_params"]["60sec_delay"])
         pass_logs = list(x[1] for x in responses_rd["pass_res"])
         fail_logs = list(x[1] for x in responses_rd["fail_res"])
-        resp = self.ha_obj.check_s3bench_log(file_paths=pass_logs)
-        assert_utils.assert_false(len(resp[1]), "READs/VerifyDI logs which contain failures:"
-                                                f"{resp[1]}")
-        resp = self.ha_obj.check_s3bench_log(file_paths=fail_logs)
-        assert_utils.assert_false(len(resp[1]), "READs/VerifyDI Logs which contain failures: "
-                                                f"{resp[1]}")
+        all_logs = pass_logs + fail_logs
+        resp = self.ha_obj.check_s3bench_log(file_paths=all_logs)
+        assert_utils.assert_false(len(resp[1]), "READs/VerifyDI after pod restart are "
+                                  "expected to pass. Logs which contain failures:"
+                                  f" {resp[1]}. Logs for IOs when event was clear: {pass_logs}. "
+                                  f"Logs for IOs when event was set: {fail_logs}")
         LOGGER.info("Step 10: Verified status for In-flight READs/Verify DI")
 
         if CMN_CFG["dtm0_disabled"]:

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -957,9 +957,11 @@ class TestDataServerPodRestart:
     @pytest.mark.tags("TEST-45536")
     def test_io_datapod_serverpod_rst(self):
         """
-        Verify IO when 1 data pod and 1 server pod down and then restart by replica
-        method (one-by-one)
+        Verify IO when 1 data pod and 1 server pod down and then restart data pod by replica
+        method and Read/verify during server pod restart
         """
+        LOGGER.info("STARTED: Verify IO when 1 data pod and 1 server pod down and then restart"
+                    " data pod by replica method and Read/verify during server pod restart")
         LOGGER.info("STEP 1: Perform WRITEs/READs/Verify with variable object sizes")
         users = self.mgnt_ops.create_account_users(nusers=1)
         self.test_prefix = f'test-45536-{int(perf_counter_ns())}'
@@ -1140,5 +1142,5 @@ class TestDataServerPodRestart:
         assert_utils.assert_true(resp[0], resp[1])
         LOGGER.info("Step 12: Performed WRITEs-READs-Verify with variable sizes objects after pod "
                     "restart")
-        LOGGER.info("COMPLETED: Verify IO when 1 data pod and 1 server pod down and then restart "
-                    "by replica method (one-by-one)")
+        LOGGER.info("COMPLETED: Verify IO when 1 data pod and 1 server pod down and then restart"
+                    " data pod by replica method and Read/verify during server pod restart")

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -865,25 +865,17 @@ class TestDataServerPodRestart:
         LOGGER.info("STEP 10.1: Performed READs/Verify on data written in healthy mode in step-1")
 
         if CMN_CFG["dtm0_disabled"]:
+            degraded_mode_prefix_list = [self.test_prefix_deg, self.test_prefix_datapod_restart]
             LOGGER.info("STEP 10.2: Perform READs/Verify on data written in degraded mode when "
-                        "data pod down in step-4")
-            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                        log_prefix=self.test_prefix_deg,
-                                                        skipwrite=True, skipcleanup=True,
-                                                        setup_s3bench=False, nsamples=5, nclients=5)
-            assert_utils.assert_true(resp[0], resp[1])
+                        "data pod down in step-4 and restart at step-8")
+            for test_prefix in degraded_mode_prefix_list:
+                resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                            log_prefix=test_prefix, skipwrite=True,
+                                                            skipcleanup=True, setup_s3bench=False,
+                                                            nsamples=5, nclients=5)
+                assert_utils.assert_true(resp[0], resp[1])
             LOGGER.info("STEP 10.2: Performed READs/Verify on data written in degraded mode when"
-                        " data pod down in step-4")
-
-            LOGGER.info("STEP 10.3: Perform READs/Verify on data written after data pod restart "
-                        "in step-8")
-            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                        log_prefix=self.test_prefix_datapod_restart,
-                                                        skipwrite=True, skipcleanup=True,
-                                                        setup_s3bench=False, nsamples=5, nclients=5)
-            assert_utils.assert_true(resp[0], resp[1])
-            LOGGER.info("STEP 10.3: Performed READs/Verify on data written after data pod restart "
-                        "in step-8")
+                        " data pod down in step-4 and restart at step-8")
 
         if CMN_CFG["dtm0_disabled"]:
             LOGGER.info("Step 11: Create new bucket and perform WRITEs/READs/Verify with variable "
@@ -929,35 +921,18 @@ class TestDataServerPodRestart:
         LOGGER.info("Step 13.1: Performed READs/Verify on data written in healthy mode in step-1")
 
         if CMN_CFG["dtm0_disabled"]:
+            degraded_mode_prefix_list = [self.test_prefix_deg, self.test_prefix_datapod_restart,
+                                         self.test_prefix_server_deg]
             LOGGER.info("STEP 13.2: Perform READs/Verify on data written after data pod down "
-                        "in step-4")
-            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                        log_prefix=self.test_prefix_deg,
-                                                        skipwrite=True, skipcleanup=True,
-                                                        setup_s3bench=False, nsamples=5, nclients=5)
-            assert_utils.assert_true(resp[0], resp[1])
-            LOGGER.info("Step 13.1: Performed READs/Verify on data written after data pod down "
-                        "in step-4")
-
-            LOGGER.info("STEP 13.3: Perform READs/Verify on data written after data pod restart "
-                        "in step-8")
-            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                        log_prefix=self.test_prefix_datapod_restart,
-                                                        skipwrite=True, skipcleanup=True,
-                                                        setup_s3bench=False, nsamples=5, nclients=5)
-            assert_utils.assert_true(resp[0], resp[1])
-            LOGGER.info("Step 13.3: Performed READs/Verify on data written after data pod restart "
-                        "in step-8")
-
-            LOGGER.info("STEP 13.4: Perform READs/Verify on data written after server pod down "
-                        "in step-11")
-            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
-                                                        log_prefix=self.test_prefix_server_deg,
-                                                        skipwrite=True, skipcleanup=True,
-                                                        setup_s3bench=False, nsamples=5, nclients=5)
-            assert_utils.assert_true(resp[0], resp[1])
-            LOGGER.info("Step 13.4: Performed READs/Verify on data written after server pod down "
-                        "in step-11")
+                        "in step-4, data pod restart in step-8 and server pod down step-11")
+            for test_prefix in degraded_mode_prefix_list:
+                resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                            log_prefix=test_prefix, skipwrite=True,
+                                                            skipcleanup=True, setup_s3bench=False,
+                                                            nsamples=5, nclients=5)
+                assert_utils.assert_true(resp[0], resp[1])
+            LOGGER.info("Step 13.2: Performed READs/Verify on data written after data pod down "
+                        "in step-4, data pod restart in step-8 and server pod down step-11")
 
         if CMN_CFG["dtm0_disabled"]:
             LOGGER.info("Step 14: Create new IAM user and buckets, Perform WRITEs-READs-Verify "

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -176,7 +176,7 @@ class TestDataServerPodRestart:
             resp = sysutils.check_ping(host=self.node_ip)
             assert_utils.assert_true(resp, "Interface is still not up.")
         LOGGER.info("Cleanup: Check cluster status and start it if not up.")
-        resp = self.ha_obj.poll_cluster_status(self.node_master_list[0])
+        resp = self.ha_obj.poll_cluster_status(self.node_master_list[0], timeout=180)
         assert_utils.assert_true(resp[0], resp)
         for file in self.extra_files:
             if os.path.exists(file):

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart.py
@@ -723,3 +723,450 @@ class TestDataServerPodRestart:
                     "buckets")
         LOGGER.info("COMPLETED: Verify Continuous IO when any 1 data pod and any 1 server pod"
                     " restart by replica method")
+
+    @pytest.mark.ha
+    @pytest.mark.lc
+    @pytest.mark.tags("TEST-45529")
+    def test_io_datapod_rst_serverpod_rst(self):
+        """
+        Verify IO when 1 data pod restart and then verify IO when 1 server pod restart by replica
+        method
+        """
+        LOGGER.info("STARTED: Verify IO when 1 data pod restart and then verify IO when 1 server "
+                    "pod restart by replica method")
+        LOGGER.info("STEP 1: Perform WRITEs/READs/Verify with variable object sizes")
+        users = self.mgnt_ops.create_account_users(nusers=1)
+        self.test_prefix = f'test-45529-{int(perf_counter_ns())}'
+        self.s3_clean.update(users)
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipcleanup=True,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("STEP 1: Performed WRITEs/READs/Verify with variable sizes objects")
+
+        LOGGER.info("STEP 2: Shutdown one data pod with replica method and verify cluster & "
+                    "remaining pods status")
+        pod_prefix = const.POD_NAME_PREFIX
+        num_replica = self.pod_dict[pod_prefix][-1] - 1
+        resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+            master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+            pod_prefix=[pod_prefix], delete_pod=[self.pod_dict.get(pod_prefix)[0]],
+            num_replica=num_replica)
+        assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+        pod_name = list(resp[1].keys())[0]
+        self.pod_dict[pod_prefix].append(resp[1][pod_name]['deployment_name'])
+        self.pod_dict[pod_prefix].append(resp[1][pod_name]['method'])
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("Step 2: Successfully shutdown one data pod with replica method and verify "
+                    "cluster & remaining pods status")
+
+        LOGGER.info("STEP 3: Perform READs/Verify on data written in healthy cluster in step-1")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipwrite=True,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("STEP 3: Performed READs/Verify on data written in healthy cluster in step-1")
+
+        if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("STEP 4: Create new bucket and perform WRITEs/READs/Verify with variable "
+                        "object sizes in degraded mode")
+            self.test_prefix_deg = f'test-45529-deg-{int(perf_counter_ns())}'
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_deg,
+                                                        skipcleanup=True, setup_s3bench=False,
+                                                        nsamples=5, nclients=5)
+            assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("STEP 4: Create new objects and perform WRITEs/READs/Verify with variable "
+                    "object sizes in degraded mode")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("STEP 4: Performed WRITEs/READs/Verify with variable sizes objects in "
+                    "degraded mode")
+
+        LOGGER.info("STEP 5: Restore data pod and check cluster status.")
+        pod = const.POD_NAME_PREFIX
+        self.restore_method = self.pod_dict.get(pod)[-1]
+        resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
+                                       restore_method=self.restore_method,
+                                       restore_params={
+                                           "deployment_name": self.pod_dict.get(pod)[-2],
+                                           "deployment_backup": self.deployment_backup,
+                                           "num_replica": self.pod_dict.get(pod)[2],
+                                           "set_name": self.pod_dict.get(pod)[1]})
+        LOGGER.debug("Response: %s", resp)
+        assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method} way")
+        LOGGER.info("Successfully restored pod by %s way", self.restore_method)
+        LOGGER.info("STEP 5: Successfully started data pod and cluster is online.")
+        self.restore_pod = False
+
+        LOGGER.info("STEP 6: Perform READ/Verify on data written with buckets created in healthy "
+                    "mode in step-1")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipwrite=True,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("STEP 6: Successfully run READ/Verify on data written with buckets created in "
+                    "healthy mode in step-1")
+
+        if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("STEP 7: Perform READs and verify DI on the data written on buckets "
+                        "created in degraded mode in step-4")
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_deg,
+                                                        skipwrite=True, skipcleanup=True,
+                                                        setup_s3bench=False, nsamples=5, nclients=5)
+            assert_utils.assert_true(resp[0], resp[1])
+            LOGGER.info("STEP 7: Successfully run READ/Verify on data written on buckets created "
+                        "in degraded mode in step-4")
+
+        if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("STEP 8: Create new IAM user and buckets, Perform WRITEs-READs-Verify with "
+                        "variable object sizes after data pod restart")
+            users = self.mgnt_ops.create_account_users(nusers=1)
+            self.test_prefix_datapod_restart = f'test-45510-restart-{int(perf_counter_ns())}'
+            self.s3_clean.update(users)
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_datapod_restart,
+                                                        skipcleanup=True, setup_s3bench=False,
+                                                        nsamples=5, nclients=5)
+            assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("STEP 8: Create new objects and perform WRITEs/READs/Verify with variable "
+                    "object sizes after data pod restart")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("STEP 8: Performed WRITEs-READs-Verify with variable sizes objects after "
+                    "data pod restart")
+
+        LOGGER.info("STEP 9: Shutdown one server pod with replica method and verify cluster & "
+                    "remaining pods status")
+        pod_prefix = const.const.SERVER_POD_NAME_PREFIX
+        num_replica = self.pod_dict[pod_prefix][-1] - 1
+        resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+            master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+            pod_prefix=[pod_prefix], delete_pod=[self.pod_dict.get(pod_prefix)[0]],
+            num_replica=num_replica)
+        assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+        pod_name = list(resp[1].keys())[0]
+        self.pod_dict[pod_prefix].append(resp[1][pod_name]['deployment_name'])
+        self.pod_dict[pod_prefix].append(resp[1][pod_name]['method'])
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("STEP 9: Successfully shutdown one server pod with replica method and verify "
+                    "cluster & remaining pods status")
+
+        LOGGER.info("STEP 10.1: Perform READs/Verify on data written in healthy mode in step-1")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipwrite=True,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("STEP 10.1: Performed READs/Verify on data written in healthy mode in step-1")
+
+        if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("STEP 10.2: Perform READs/Verify on data written in degraded mode when "
+                        "data pod down in step-4")
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_deg,
+                                                        skipwrite=True, skipcleanup=True,
+                                                        setup_s3bench=False, nsamples=5, nclients=5)
+            assert_utils.assert_true(resp[0], resp[1])
+            LOGGER.info("STEP 10.2: Performed READs/Verify on data written in degraded mode when"
+                        " data pod down in step-4")
+
+            LOGGER.info("STEP 10.3: Perform READs/Verify on data written after data pod restart "
+                        "in step-8")
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_deg,
+                                                        skipwrite=True, skipcleanup=True,
+                                                        setup_s3bench=False, nsamples=5, nclients=5)
+            assert_utils.assert_true(resp[0], resp[1])
+            LOGGER.info("STEP 10.3: Performed READs/Verify on data written after data pod restart "
+                        "in step-8")
+
+        if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("Step 11: Create new bucket and perform WRITEs/READs/Verify with variable "
+                        "object sizes when server pod down")
+            self.test_prefix_server_deg = f'test-45529-server_deg-{int(perf_counter_ns())}'
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_server_deg,
+                                                        skipcleanup=True, setup_s3bench=False,
+                                                        nsamples=5, nclients=5)
+            assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 11: Create new objects and perform WRITEs/READs/Verify with variable "
+                    "object sizes when server pod down")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 11: Performed WRITEs/READs/Verify with variable object sizes "
+                    "when server pod down")
+
+        LOGGER.info("Step 12: Restore server pod and check cluster status.")
+        pod_prefix = const.SERVER_POD_NAME_PREFIX
+        self.restore_method = self.pod_dict.get(pod_prefix)[-1]
+        resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
+                                       restore_method=self.restore_method,
+                                       restore_params={
+                                           "deployment_name": self.pod_dict.get(pod_prefix)[-2],
+                                           "deployment_backup": self.deployment_backup,
+                                           "num_replica": self.pod_dict.get(pod_prefix)[2],
+                                           "set_name": self.pod_dict.get(pod_prefix)[1]})
+        LOGGER.debug("Response: %s", resp)
+        assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method} way")
+        LOGGER.info("Successfully restored pod by %s way", self.restore_method)
+        LOGGER.info("Step 12: Successfully started server pod and cluster is online.")
+        self.restore_pod = False
+
+        LOGGER.info("STEP 13.1: Perform READs/Verify on data written in healthy mode in step-1")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipwrite=True,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 13.1: Performed READs/Verify on data written in healthy mode in step-1")
+
+        if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("STEP 13.2: Perform READs/Verify on data written after data pod down "
+                        "in step-4")
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_deg,
+                                                        skipwrite=True, skipcleanup=True,
+                                                        setup_s3bench=False, nsamples=5, nclients=5)
+            assert_utils.assert_true(resp[0], resp[1])
+            LOGGER.info("Step 13.1: Performed READs/Verify on data written after data pod down "
+                        "in step-4")
+
+            LOGGER.info("STEP 13.3: Perform READs/Verify on data written after data pod restart "
+                        "in step-8")
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_datapod_restart,
+                                                        skipwrite=True, skipcleanup=True,
+                                                        setup_s3bench=False, nsamples=5, nclients=5)
+            assert_utils.assert_true(resp[0], resp[1])
+            LOGGER.info("Step 13.3: Performed READs/Verify on data written after data pod restart "
+                        "in step-8")
+
+            LOGGER.info("STEP 13.4: Perform READs/Verify on data written after server pod down "
+                        "in step-11")
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_server_deg,
+                                                        skipwrite=True, skipcleanup=True,
+                                                        setup_s3bench=False, nsamples=5, nclients=5)
+            assert_utils.assert_true(resp[0], resp[1])
+            LOGGER.info("Step 13.4: Performed READs/Verify on data written after server pod down "
+                        "in step-11")
+
+        if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("Step 14: Create new IAM user and buckets, Perform WRITEs-READs-Verify "
+                        "with variable object sizes after data pod restart")
+            users = self.mgnt_ops.create_account_users(nusers=1)
+            self.test_prefix = f'test-45510-restart-{int(perf_counter_ns())}'
+            self.s3_clean.update(users)
+        else:
+            LOGGER.info("Step 14: Create new objects, Perform WRITEs-READs-Verify with variable "
+                        "object sizes after data and server pod restart")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 14: Performed WRITEs-READs-Verify with variable sizes objects after "
+                    "data and server pod restart")
+        LOGGER.info("COMPLETED: Verify IO when 1 data pod restart and then verify IO when 1 "
+                    "server pod restart by replica method")
+
+    @pytest.mark.ha
+    @pytest.mark.lc
+    @pytest.mark.tags("TEST-45536")
+    def test_io_datapod_serverpod_rst(self):
+        """
+        Verify IO when 1 data pod and 1 server pod down and then restart by replica
+        method (one-by-one)
+        """
+        LOGGER.info("STEP 1: Perform WRITEs/READs/Verify with variable object sizes")
+        users = self.mgnt_ops.create_account_users(nusers=1)
+        self.test_prefix = f'test-45536-{int(perf_counter_ns())}'
+        self.s3_clean.update(users)
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipcleanup=True,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 1: Performed WRITEs/READs/Verify with variable sizes objects")
+
+        LOGGER.info("Step 2: Shutdown one data pod with replica method and verify cluster & "
+                    "remaining pods status")
+        pod_prefix = const.POD_NAME_PREFIX
+        num_replica = self.pod_dict[pod_prefix][-1] - 1
+        resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+            master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+            pod_prefix=[pod_prefix], delete_pod=[self.pod_dict.get(pod_prefix)[0]],
+            num_replica=num_replica)
+        assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+        pod_name = list(resp[1].keys())[0]
+        self.pod_dict[pod_prefix].append(resp[1][pod_name]['deployment_name'])
+        self.pod_dict[pod_prefix].append(resp[1][pod_name]['method'])
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("Step 2: Successfully shutdown one data pod with replica method and verify "
+                    "cluster & remaining pods status")
+
+        LOGGER.info("STEP 3: Perform READs/Verify on data written in healthy cluster in step-1")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipwrite=True,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 3: Performed READs/Verify on data written in healthy cluster in step-1")
+
+        if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("Step 4: Create new bucket and perform WRITEs/READs/Verify with variable "
+                        "object sizes in degraded mode")
+            self.test_prefix_deg = f'test-45536-deg-{int(perf_counter_ns())}'
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_deg,
+                                                        skipcleanup=True, setup_s3bench=False,
+                                                        nsamples=5, nclients=5)
+            assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 4: Create new objects and perform WRITEs/READs/Verify with variable "
+                    "object sizes in degraded mode")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 4: Performed WRITEs/READs/Verify with variable sizes objects in "
+                    "degraded mode")
+
+        LOGGER.info("Step 5: Shutdown one server pod with replica method and verify cluster & "
+                    "remaining pods status")
+        pod_prefix = const.SERVER_POD_NAME_PREFIX
+        num_replica = self.pod_dict[pod_prefix][-1] - 1
+        resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+            master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+            pod_prefix=[pod_prefix], delete_pod=[self.pod_dict.get(pod_prefix)[0]],
+            num_replica=num_replica)
+        assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+        pod_name = list(resp[1].keys())[0]
+        self.pod_dict[pod_prefix].append(resp[1][pod_name]['deployment_name'])
+        self.pod_dict[pod_prefix].append(resp[1][pod_name]['method'])
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
+        self.restore_pod = True
+        assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+        LOGGER.info("Step 5: Successfully shutdown one server pod with replica method and verify "
+                    "cluster & remaining pods status")
+
+        LOGGER.info("STEP 6.1: Perform READs/Verify on data written in healthy cluster in step-1")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipwrite=True,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 6.1: Performed READs/Verify on data written in healthy cluster in step-1")
+
+        if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("STEP 6.2: Perform READs/Verify on data written in degraded mode when "
+                        "data pod down in step-4")
+            resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                        log_prefix=self.test_prefix_deg,
+                                                        skipwrite=True, skipcleanup=True,
+                                                        setup_s3bench=False, nsamples=5, nclients=5)
+            assert_utils.assert_true(resp[0], resp[1])
+            LOGGER.info("Step 6.2: Performed READs/Verify on data written in degraded mode when "
+                        "data pod down in step-4")
+
+        LOGGER.info("STEP 7: Perform write when data and server pod is down")
+        if CMN_CFG["dtm0_disabled"]:
+            self.test_prefix = 'test-34076-deg-write'
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix, skipread=True,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 7: Performed write when data and server pod is down")
+
+        LOGGER.info("Step 8: Start READs and verify DI on the written data when pods down in "
+                    "step-7 in background")
+        output_rd = Queue()
+        event = threading.Event()
+        event_set_clr = [False]
+        args = {'s3userinfo': list(users.values())[0], 'log_prefix': self.test_prefix,
+                'nclients': 5, 'nsamples': 5, 'skipwrite': True, 'skipcleanup': True,
+                'output': output_rd, 'setup_s3bench': False, 'event_set_clr': event_set_clr}
+        thread_rd = threading.Thread(target=self.ha_obj.event_s3_operation, args=(event,),
+                                     kwargs=args)
+        thread_rd.daemon = True  # Daemonize thread
+        thread_rd.start()
+        LOGGER.info("Step 8: Successfully started READs and verify on the written data when pods "
+                    "down in step-7 in background")
+        LOGGER.info("Waiting for %s seconds", HA_CFG["common_params"]["30sec_delay"])
+        time.sleep(HA_CFG["common_params"]["30sec_delay"])
+
+        LOGGER.info("Step 9: Restore data and server pod and check cluster status.")
+        event.set()
+        for pod_prefix in self.pod_dict:
+            self.restore_method = self.pod_dict.get(pod_prefix)[-1]
+            resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
+                                           restore_method=self.restore_method,
+                                           restore_params={
+                                               "deployment_name": self.pod_dict.get(pod_prefix)[-2],
+                                               "deployment_backup": self.deployment_backup,
+                                               "num_replica": self.pod_dict.get(pod_prefix)[2],
+                                               "set_name": self.pod_dict.get(pod_prefix)[1]},
+                                           clstr_status=True)
+            LOGGER.debug("Response: %s", resp)
+            assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method} way")
+            LOGGER.info("Successfully restored pod by %s way", self.restore_method)
+        LOGGER.info("Step 9: Successfully started data and server pod and cluster is online.")
+        self.restore_pod = False
+        event.clear()
+        thread_rd.join()
+
+        LOGGER.info("Step 10: Verify status for In-flight READs/Verify DI")
+        responses_rd = dict()
+        while len(responses_rd) != 2:
+            responses_rd = output_rd.get(timeout=HA_CFG["common_params"]["60sec_delay"])
+        pass_logs = list(x[1] for x in responses_rd["pass_res"])
+        fail_logs = list(x[1] for x in responses_rd["fail_res"])
+        resp = self.ha_obj.check_s3bench_log(file_paths=pass_logs)
+        assert_utils.assert_false(len(resp[1]), "READs/VerifyDI logs which contain failures:"
+                                                f"{resp[1]}")
+        resp = self.ha_obj.check_s3bench_log(file_paths=fail_logs)
+        assert_utils.assert_false(len(resp[1]), "READs/VerifyDI Logs which contain failures: "
+                                                f"{resp[1]}")
+        LOGGER.info("Step 10: Verified status for In-flight READs/Verify DI")
+
+        if CMN_CFG["dtm0_disabled"]:
+            LOGGER.info("Step 11: Create new IAM user and buckets, Perform WRITEs-READs-Verify "
+                        "with variable object sizes after pod restart")
+            users = self.mgnt_ops.create_account_users(nusers=1)
+            self.test_prefix = f'test-45536-restart-{int(perf_counter_ns())}'
+            self.s3_clean.update(users)
+        else:
+            LOGGER.info("Step 11: Create new objects, Perform WRITEs-READs-Verify with "
+                        "variable object sizes after pod restart")
+        resp = self.ha_obj.ha_s3_workload_operation(s3userinfo=list(users.values())[0],
+                                                    log_prefix=self.test_prefix,
+                                                    skipcleanup=True, setup_s3bench=False,
+                                                    nsamples=5, nclients=5)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 11: Performed WRITEs-READs-Verify with variable sizes objects after pod "
+                    "restart")
+        LOGGER.info("COMPLETED: Verify IO when 1 data pod and 1 server pod down and then restart "
+                    "by replica method (one-by-one)")


### PR DESCRIPTION
Signed-off-by: RAHUL HATWAR <rahulchandrakant.hatwar@seagate.com>

# Problem Statement
Data and Server pod restart - TEST-45529, 45536

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide
Collection logs : 
ct.py::TestVersioningGetHeadObject::test_get_head_object_versioned_bucket_32731', 'test_id': 'TEST-32731', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_object_versioned_bucket_32729', 'test_id': 'TEST-32729', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[None]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Enabled]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Suspended]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_preexist_mpu_versioning_enabled_bkt_41284', 'test_id': 'TEST-41284', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_ver_enabled_bkt_41285', 'test_id': 'TEST-41285', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_versioning_suspended_bkt_41286', 'test_id': 'TEST-41286', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_del_versioning_enabled_bkt_41287', 'test_id': 'TEST-41287', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_abort_multipart_upload_does_not_create_a_new_version_41288', 'test_id': 'TEST-41288', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_upload_multiple_versions_to_multipart_uploaded_object_in_versioned_bucket_41289', 'test_id': 'TEST-41289', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_upload_new_versions_to_existing_objects_using_multipart_upload_41290', 'test_id': 'TEST-41290', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_preexisting_32724', 'test_id': 'TEST-32724', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_enabled_32728', 'test_id': 'TEST-32728', 'marks': ['s3_ops', 'sanity']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_suspended_32733', 'test_id': 'TEST-32733', 'marks': ['s3_ops']}, {'nodeid': 'tests/security/test_cortx_port_scanner_kubectl_svc.py::test_cortx_port_scanner_kubectl_svc', 'test_id': 'TEST-34217', 'marks': ['security']}, {'nodeid': 'tests/security/test_cortx_port_scanner_netstat.py::test_cortx_port_scanner_netstat', 'test_id': 'TEST-34218', 'marks': ['security']}] created at /root/rahul_workspace/cortx-test-1/log/te_meta.json
Successfully unmounted directory

=========================================== 2422 tests collected in 7.57s ============================================
(virenv) [root@ssc-vm-g3-rhev4-2524 cortx-test-1]#
