### PR TITLE
Execute tests in given JIRA Rank

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -525,8 +525,8 @@ def pytest_collection(session):
     else:
         required_tests = read_test_list_csv()  # e.g. required_tests = ['TEST-17413', 'TEST-17414']
         Globals.TE_TKT = config.option.te_tkt
-        selected_items = []
-        selected_tests = []
+        selected_items = [None] * len(required_tests)
+        selected_tests = [None] * len(required_tests)
         for item in items:
             parallel_found = False
             test_found = ''
@@ -539,9 +539,13 @@ def pytest_collection(session):
                     test_found = mark.args[0]
             if parallel_found == is_parallel and test_found != '':
                 if test_found in required_tests:
-                    selected_items.append(item)
-                    selected_tests.append(test_found)
+                    index = required_tests.index(test_found)
+                    selected_items[index] = item
+                    selected_tests[index] = test_found
             CACHE.store(item.nodeid, test_found)
+        selected_items = list(filter(lambda x: x, selected_items))
+        selected_tests = list(filter(lambda x: x, selected_tests))
+        LOGGER.info("Items = %s", selected_tests)
         with open(os.path.join(os.getcwd(), params.LOG_DIR_NAME, params.JIRA_SELECTED_TESTS), 'w') \
                 as test_file:
             write = csv.writer(test_file)


### PR DESCRIPTION
# Problem Statement
- Currently tests are executed randomly or based on pytest collection sequence. Modified pytest_collection, to execute Tests based in JIRA Rank sequence in given Test Execution.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [x] New/Affected tests are executed on Latest Build
-  [x] Attach test execution logs
-  [x] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [x] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide