### PR TITLE
Data and Server pod restart - TEST-45535

### DIFF
--- a/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
@@ -1047,9 +1047,10 @@ class TestDataServerPodRestartAPI:
     @pytest.mark.tags("TEST-45535")
     def test_bkt_ver_during_data_server_pod_rst(self):
         """
-        Verify bucket versioning during 1 data pod and 1 server pod restart
+        Verify bucket versioning during single data pod and single server pod restart
         """
-        LOGGER.info("STARTED: Verify bucket versioning during 1 data pod and 1 server pod restart.")
+        LOGGER.info("STARTED: Verify bucket versioning during single data pod and single server "
+                    "pod restart.")
         event = threading.Event()
         get_output = Queue()
         put_output = Queue()
@@ -1205,5 +1206,5 @@ class TestDataServerPodRestartAPI:
         assert_utils.assert_true(resp[0], f"Get Object with versionID failed {resp[1]}")
         LOGGER.info("Step 11: Got object versions of %s & verified etags for %s.",
                     self.object_name, new_bucket)
-        LOGGER.info("COMPLETED: Verify bucket versioning during 1 data pod and 1 server pod "
-                    "restart.")
+        LOGGER.info("COMPLETED: Verify bucket versioning during single data pod and single server "
+                    "pod restart.")

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
@@ -1056,12 +1056,12 @@ class TestDataServerPodRestartAPI:
         put_output = Queue()
         LOGGER.info("Step 1: Create bucket and upload object %s of %s size. Enable versioning "
                     "on %s.", self.object_name, self.f_size, self.bucket_name)
-        self.extra_files.append(self.multipart_obj_path)
         args = {'chk_null_version': True, 'is_unversioned': True,
                 'file_path': self.multipart_obj_path, 'enable_ver': True, 's3_ver': self.s3_ver}
         resp = self.ha_api.crt_bkt_put_obj_enbl_ver(event, self.s3_test_obj, self.bucket_name,
                                                     self.object_name, **args)
         assert_utils.assert_true(resp[0], resp[1])
+        self.extra_files.append(self.multipart_obj_path)
         LOGGER.info("Step 1: Created bucket and uploaded object %s of %s size. Enabled "
                     "versioning on %s.", self.object_name, self.f_size, self.bucket_name)
         self.version_etag.update({self.bucket_name: []})

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
@@ -49,6 +49,7 @@ from libs.s3.s3_blackbox_test_lib import JCloudClient
 from libs.s3.s3_rest_cli_interface_lib import S3AccountOperations
 from libs.s3.s3_multipart_test_lib import S3MultipartTestLib
 from libs.s3.s3_test_lib import S3TestLib
+from libs.s3.s3_versioning_test_lib import S3VersioningTestLib
 
 # Global Constants
 LOGGER = logging.getLogger(__name__)
@@ -68,6 +69,7 @@ class TestDataServerPodRestartAPI:
         """
         LOGGER.info("STARTED: Setup Module operations.")
         cls.num_nodes = len(CMN_CFG["nodes"])
+        cls.setup_type = CMN_CFG["setup_type"]
         cls.username = list()
         cls.password = list()
         cls.node_master_list = list()
@@ -77,7 +79,8 @@ class TestDataServerPodRestartAPI:
         cls.random_time = cls.s3_clean = cls.test_prefix = cls.multipart_obj_path = None
         cls.ha_api = HAK8sApiLibs()
         cls.random_time = cls.s3_clean = cls.test_prefix = cls.s3_test_obj = None
-        cls.s3acc_name = cls.s3acc_email = cls.bucket_name = cls.object_name = None
+        cls.multipart_obj_path = cls.set_name = cls.version_etag = cls.extra_files = None
+        cls.s3acc_name = cls.s3acc_email = cls.bucket_name = cls.object_name = cls.s3_ver = None
         cls.system_random = secrets.SystemRandom()
         cls.mgnt_ops = ManagementOPs()
 
@@ -108,6 +111,7 @@ class TestDataServerPodRestartAPI:
         LOGGER.info("STARTED: Setup Operations")
         self.random_time = int(time.time())
         self.s3_clean = dict()
+        self.version_etag = dict()
         self.restore_pod = self.restore_method = self.deployment_name = self.set_name = None
         self.deployment_backup = None
         if not os.path.exists(self.test_dir_path):
@@ -153,6 +157,13 @@ class TestDataServerPodRestartAPI:
         secret_key = list(users.values())[0]["secretkey"]
         self.s3_test_obj = S3TestLib(access_key=access_key, secret_key=secret_key,
                                      endpoint_url=S3_CFG["s3_url"])
+        self.s3_ver = S3VersioningTestLib(access_key=access_key, secret_key=secret_key,
+                                          endpoint_url=S3_CFG["s3_url"], region=S3_CFG["region"])
+        LOGGER.info("Created IAM user")
+        if self.setup_type == "VM":
+            self.f_size = str(HA_CFG["5gb_mpu_data"]["file_size_512M"]) + "M"
+        else:
+            self.f_size = str(HA_CFG["5gb_mpu_data"]["file_size"]) + "M"
         LOGGER.info("COMPLETED: Setup operations.")
 
     def teardown_method(self):
@@ -1029,4 +1040,170 @@ class TestDataServerPodRestartAPI:
                                                           f"for object {obj} of bucket {bkt}.")
         LOGGER.info("Step 9: Downloaded copied objects & verify etags.")
         LOGGER.info("COMPLETED: Verify copy object during single data pod and single server pod "
+                    "restart.")
+
+    @pytest.mark.ha
+    @pytest.mark.lc
+    @pytest.mark.tags("TEST-45535")
+    def test_bkt_ver_during_data_server_pod_rst(self):
+        """
+        Verify bucket versioning during 1 data pod and 1 server pod restart
+        """
+        LOGGER.info("STARTED: Verify bucket versioning during 1 data pod and 1 server pod restart.")
+        event = threading.Event()
+        get_output = Queue()
+        put_output = Queue()
+        LOGGER.info("Step 1: Create bucket and upload object %s of %s size. Enable versioning "
+                    "on %s.", self.object_name, self.f_size, self.bucket_name)
+        self.extra_files.append(self.multipart_obj_path)
+        args = {'chk_null_version': True, 'is_unversioned': True,
+                'file_path': self.multipart_obj_path, 'enable_ver': True, 's3_ver': self.s3_ver}
+        resp = self.ha_api.crt_bkt_put_obj_enbl_ver(event, self.s3_test_obj, self.bucket_name,
+                                                    self.object_name, **args)
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 1: Created bucket and uploaded object %s of %s size. Enabled "
+                    "versioning on %s.", self.object_name, self.f_size, self.bucket_name)
+        self.version_etag.update({self.bucket_name: []})
+        self.version_etag[self.bucket_name].extend(resp[1])
+        LOGGER.info("Step 2: Upload same object %s after enabling versioning. List & verify "
+                    "the VersionID for the same for %s.", self.object_name, self.bucket_name)
+        args = {'file_path': self.multipart_obj_path}
+        resp = self.ha_api.parallel_put_object(event, self.s3_test_obj, self.bucket_name,
+                                               self.object_name, **args)
+        assert_utils.assert_true(resp[0], f"Upload Object failed {resp[1]}")
+        self.version_etag[self.bucket_name].extend(resp[1])
+        resp = self.ha_api.list_verify_version(self.s3_ver, self.bucket_name, self.version_etag[
+            self.bucket_name])
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 2: Uploaded same object %s after enabling versioning. Listed & verified"
+                    " the VersionID for the same for %s.", self.object_name, self.bucket_name)
+        LOGGER.info("Step 3: Shutdown one data and one server pod with replica method and verify"
+                    " cluster & remaining pods status")
+        for pod_prefix in self.pod_dict:
+            num_replica = self.pod_dict[pod_prefix][-1] - 1
+            resp = self.ha_obj.delete_kpod_with_shutdown_methods(
+                master_node_obj=self.node_master_list[0], health_obj=self.hlth_master_list[0],
+                pod_prefix=[pod_prefix], delete_pod=[self.pod_dict.get(pod_prefix)[0]],
+                num_replica=num_replica)
+            assert_utils.assert_true(resp[1], "Failed to shutdown/delete pod")
+            pod_name = list(resp[1].keys())[0]
+            self.pod_dict[pod_prefix].append(resp[1][pod_name]['deployment_name'])
+            self.pod_dict[pod_prefix].append(resp[1][pod_name]['method'])
+            assert_utils.assert_true(resp[0], "Cluster/Services status is not as expected")
+            LOGGER.info("successfully shutdown pod %s", self.pod_dict.get(pod_prefix)[0])
+            self.restore_pod = True
+        LOGGER.info("Step 3: Successfully shutdown one data and one server pod. Verified cluster "
+                    "and services states are as expected & remaining pods status is online")
+        LOGGER.info("Step 4: Get object versions of %s with VersionID & verify etags for %s.",
+                    self.object_name, self.bucket_name)
+        resp = self.ha_api.parallel_get_object(event=event, s3_ver_obj=self.s3_ver,
+                                               bkt_name=self.bucket_name, obj_name=self.object_name,
+                                               ver_etag=self.version_etag[self.bucket_name])
+        assert_utils.assert_true(resp[0], f"Get Object with versionID failed {resp[1]}")
+        LOGGER.info("Step 4: Got object versions of %s with VersionID & verified etags for %s.",
+                    self.object_name, self.bucket_name)
+        count = HA_CFG["common_params"]["put_get_version"]
+        LOGGER.info("Step 5: Starting background threads for Get and Put version for count %s "
+                    "while data and server pod restarting.", count)
+        LOGGER.info("Upload same object %s for %s times for background Get.", self.object_name,
+                    count)
+        args = {'file_path': self.multipart_obj_path, 'count': count}
+        resp = self.ha_api.parallel_put_object(event, self.s3_test_obj, self.bucket_name,
+                                               self.object_name, **args)
+        assert_utils.assert_true(resp[0], f"Upload Object failed {resp[1]}")
+        self.version_etag[self.bucket_name].extend(resp[1])
+        args = {'file_path': self.multipart_obj_path, 'count': count, 'background': True}
+        put_thread = threading.Thread(
+            target=self.ha_api.parallel_put_object,
+            args=(event, self.s3_test_obj, self.bucket_name, self.object_name, put_output),
+            kwargs=args)
+        args = {'background': True, 'output': get_output}
+        get_thread = threading.Thread(
+            target=self.ha_api.parallel_get_object,
+            args=(event, self.s3_ver, self.bucket_name, self.object_name,
+                  self.version_etag[self.bucket_name]), kwargs=args)
+        LOGGER.info("Uploaded same object %s for %s times for background Get.", self.object_name,
+                    count)
+        put_thread.daemon = True  # Daemonize thread
+        get_thread.daemon = True  # Daemonize thread
+        put_thread.start()
+        get_thread.start()
+        LOGGER.info("Step 5: Started background threads for Get and Put Version")
+        LOGGER.info("Step 6: Restore data, server pod and check cluster status.")
+        event.set()
+        for pod_prefix in self.pod_dict:
+            self.restore_method = self.pod_dict.get(pod_prefix)[-1]
+            resp = self.ha_obj.restore_pod(pod_obj=self.node_master_list[0],
+                                           restore_method=self.restore_method,
+                                           restore_params={
+                                               "deployment_name": self.pod_dict.get(pod_prefix)[-2],
+                                               "deployment_backup": self.deployment_backup,
+                                               "num_replica": self.pod_dict.get(pod_prefix)[2],
+                                               "set_name": self.pod_dict.get(pod_prefix)[1]})
+            #    clstr_status=True)
+            LOGGER.debug("Response: %s", resp)
+            assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method} way")
+            LOGGER.info("Successfully restored pod by %s way", self.restore_method)
+        self.restore_pod = False
+        event.clear()
+        put_thread.join()
+        get_thread.join()
+        LOGGER.info("Step 6: Successfully started data, server pod and cluster is online.")
+        LOGGER.info("Step 7: Verify background Put & Get Version for %s", self.object_name)
+        get_resp = tuple()
+        put_resp = tuple()
+        while len(get_resp) != 2:
+            get_resp = get_output.get(timeout=HA_CFG["common_params"]["60sec_delay"])
+        while len(put_resp) != 2:
+            put_resp = put_output.get(timeout=HA_CFG["common_params"]["60sec_delay"])
+        assert_utils.assert_false(len(get_resp[1]) or len(put_resp[1]),
+                                  "Failure in put or get object during data and server pod restart"
+                                  f"GET resp: {get_resp[1]} PUT resp: {put_resp[1]}")
+        self.version_etag[self.bucket_name].extend(put_resp[0])
+        LOGGER.info("Step 7: Verified background Put & Get Version for %s", self.object_name)
+        LOGGER.info("Step 8: Get object with version IDs & verify etags for %s.", self.bucket_name)
+        resp = self.ha_api.parallel_get_object(event=event, s3_ver_obj=self.s3_ver,
+                                               bkt_name=self.bucket_name, obj_name=self.object_name,
+                                               ver_etag=self.version_etag[self.bucket_name])
+        assert_utils.assert_true(resp[0], f"Get Object with versionID failed {resp[1]}")
+        LOGGER.info("Step 8: Got object with version IDs & verified etags for %s.",
+                    self.bucket_name)
+        new_bucket = self.bucket_name
+        download_path = self.multipart_obj_path
+        if CMN_CFG["dtm0_disabled"]:
+            new_bucket = f"ha-mp-bkt-{int(perf_counter_ns())}"
+            download_path = os.path.join(self.test_dir_path, self.test_file + "_new")
+            self.extra_files.append(download_path)
+            LOGGER.info("Step 9: Create new bucket and upload object %s of %s size. Enable "
+                        "versioning on %s.", self.object_name, self.f_size, new_bucket)
+            args = {'chk_null_version': True, 'is_unversioned': True, 'file_path': download_path,
+                    'enable_ver': True, 's3_ver': self.s3_ver}
+            resp = self.ha_api.crt_bkt_put_obj_enbl_ver(event, self.s3_test_obj, new_bucket,
+                                                        self.object_name, **args)
+            assert_utils.assert_true(resp[0], resp[1])
+            self.version_etag.update({new_bucket: []})
+            self.version_etag[new_bucket].extend(resp[1])
+            LOGGER.info("Step 9: Created bucket and uploaded object %s of %s size. Enabled "
+                        "versioning on %s.", self.object_name, self.f_size, new_bucket)
+        LOGGER.info("Step 10: Upload same object %s. List & verify the VersionID for "
+                    "the same for %s.", self.object_name, new_bucket)
+        args = {'file_path': download_path}
+        resp = self.ha_api.parallel_put_object(event, self.s3_test_obj, new_bucket,
+                                               self.object_name, **args)
+        assert_utils.assert_true(resp[0], f"Upload Object failed {resp[1]}")
+        self.version_etag[new_bucket].extend(resp[1])
+        resp = self.ha_api.list_verify_version(self.s3_ver, new_bucket,
+                                               self.version_etag[new_bucket])
+        assert_utils.assert_true(resp[0], resp[1])
+        LOGGER.info("Step 10: Uploaded same object %s after enabling versioning. Listed & "
+                    "verified VersionID for the same for %s.", self.object_name, new_bucket)
+        LOGGER.info("Step 11: Get object versions of %s & verify etags for %s.",
+                    self.object_name, new_bucket)
+        resp = self.ha_api.parallel_get_object(event=event, s3_ver_obj=self.s3_ver,
+                                               bkt_name=new_bucket, obj_name=self.object_name,
+                                               ver_etag=self.version_etag[new_bucket])
+        assert_utils.assert_true(resp[0], f"Get Object with versionID failed {resp[1]}")
+        LOGGER.info("Step 11: Got object versions of %s & verified etags for %s.",
+                    self.object_name, new_bucket)
+        LOGGER.info("COMPLETED: Verify bucket versioning during 1 data pod and 1 server pod "
                     "restart.")

--- a/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
+++ b/tests/ha/single_pod_restart/test_data_server_pod_restart_api.py
@@ -1140,8 +1140,8 @@ class TestDataServerPodRestartAPI:
                                                "deployment_name": self.pod_dict.get(pod_prefix)[-2],
                                                "deployment_backup": self.deployment_backup,
                                                "num_replica": self.pod_dict.get(pod_prefix)[2],
-                                               "set_name": self.pod_dict.get(pod_prefix)[1]})
-            #    clstr_status=True)
+                                               "set_name": self.pod_dict.get(pod_prefix)[1]},
+                                           clstr_status=True)
             LOGGER.debug("Response: %s", resp)
             assert_utils.assert_true(resp[0], f"Failed to restore pod by {self.restore_method} way")
             LOGGER.info("Successfully restored pod by %s way", self.restore_method)


### PR DESCRIPTION
Signed-off-by: RAHUL HATWAR <rahulchandrakant.hatwar@seagate.com>

# Problem Statement
Data and Server pod restart - TEST-45535

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide
Collection logs : 
ersioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_object_versioned_bucket_32731', 'test_id': 'TEST-32731', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_object_versioned_bucket_32729', 'test_id': 'TEST-32729', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[None]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Enabled]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_get_head_object.py::TestVersioningGetHeadObject::test_get_head_versioned_object_invalid_32727[Suspended]', 'test_id': 'TEST-32727', 'marks': ['parametrize', 's3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_preexist_mpu_versioning_enabled_bkt_41284', 'test_id': 'TEST-41284', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_ver_enabled_bkt_41285', 'test_id': 'TEST-41285', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_versioning_suspended_bkt_41286', 'test_id': 'TEST-41286', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_mpu_del_versioning_enabled_bkt_41287', 'test_id': 'TEST-41287', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_abort_multipart_upload_does_not_create_a_new_version_41288', 'test_id': 'TEST-41288', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_upload_multiple_versions_to_multipart_uploaded_object_in_versioned_bucket_41289', 'test_id': 'TEST-41289', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_multipart.py::TestVersioningMultipart::test_upload_new_versions_to_existing_objects_using_multipart_upload_41290', 'test_id': 'TEST-41290', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_preexisting_32724', 'test_id': 'TEST-32724', 'marks': ['s3_ops']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_enabled_32728', 'test_id': 'TEST-32728', 'marks': ['s3_ops', 'sanity']}, {'nodeid': 'tests/s3/versioning/test_versioning_put_object.py::TestVersioningPutObject::test_put_object_versioning_suspended_32733', 'test_id': 'TEST-32733', 'marks': ['s3_ops']}, {'nodeid': 'tests/security/test_cortx_port_scanner_kubectl_svc.py::test_cortx_port_scanner_kubectl_svc', 'test_id': 'TEST-34217', 'marks': ['security']}, {'nodeid': 'tests/security/test_cortx_port_scanner_netstat.py::test_cortx_port_scanner_netstat', 'test_id': 'TEST-34218', 'marks': ['security']}] created at /root/rahul_workspace/cortx-test-1/log/te_meta.json
Successfully unmounted directory

=========================================== 2471 tests collected in 7.15s ============================================