### PR TITLE
CORTX-33958 Fix failing multipart tests in parallel copy operations

### DIFF
--- a/libs/s3/s3_common_test_lib.py
+++ b/libs/s3/s3_common_test_lib.py
@@ -315,6 +315,53 @@ def create_bucket_put_object(s3_tst_lib, bucket_name: str, obj_name: str, file_p
     assert_utils.assert_true(resp[0], resp[1])
     LOG.info("Uploaded an object %s to bucket %s", obj_name, bucket_name)
 
+def create_bucket_put_get_objects(bucket_name, object_count=None, obj_name_prefix=None,
+                                  obj_list=None, **kwargs):
+    """
+    Function will create a bucket with specified name, upload given no of objects
+    to the bucket and also will download the objects from bucket.
+
+    :param str bucket_name: Name of a bucket to be created.
+    :param int object_count: No of objects to be uploaded into the bucket.
+    :param str obj_name_prefix: Prefix for object name.
+    :param list obj_list: List of objects to be uploaded into the bucket and
+    downloaded from the bucket.
+    :param s3_testobj: s3 test lib object.
+    :param file_path: Path of the file to be created and uploaded to bucket.
+    :param mb_count: Size of file in MBs.
+    :return: List of objects uploaded to bucket.
+    :rtype: list
+    """
+    s3_test_object = kwargs.get("s3_testobj", "None")
+    file_path = kwargs.get("file_path", "None")
+    mb_count = kwargs.get("mb_count", "None")
+    if obj_list is None:
+        obj_list = []
+    LOG.info("Creating a bucket with name %s", bucket_name)
+    resp = s3_test_object.create_bucket(bucket_name)
+    assert_utils.assert_true(resp[0], resp[1])
+    assert resp[1] == bucket_name, resp[0]
+    LOG.info("Created a bucket with name %s", bucket_name)
+    if object_count:
+        LOG.info("Uploading %s objects to the bucket ",  object_count)
+        for cnt in range(object_count):
+            obj_name = f"{obj_name_prefix}{cnt}"
+            system_utils.create_file(file_path, mb_count)
+            resp = s3_test_object.put_object(bucket_name, obj_name, file_path)
+            assert_utils.assert_true(resp[0], resp[1])
+            obj_list.append(obj_name)
+        LOG.info("Uploaded %s objects to the bucket ", object_count)
+        return obj_list
+    if obj_list:
+        for key in obj_list:
+            system_utils.create_file(file_path, mb_count)
+            resp = s3_test_object.put_object(bucket_name, key, file_path)
+            assert_utils.assert_true(resp[0], resp[1])
+            LOG.info("Uploaded object %s to the bucket %s", key, bucket_name)
+            resp = s3_test_object.get_object(bucket_name, key)
+            assert_utils.assert_true(resp[0], resp[1])
+            LOG.info("GET operation successful for object %s from bucket %s", key, bucket_name)
+    return None
 
 def create_attach_list_iam_policy(access, secret, policy_name, iam_policy, iam_user):
     """

--- a/tests/s3/test_object_workflow_operations.py
+++ b/tests/s3/test_object_workflow_operations.py
@@ -20,11 +20,8 @@
 """Object Workflow Operations Test Module."""
 
 import os
-import random
-import string
 import time
 import logging
-import secrets
 import pytest
 
 from commons.ct_fail_on import CTFailOn
@@ -40,7 +37,7 @@ from libs.s3 import s3_test_lib
 from libs.s3 import s3_cmd_test_lib
 from libs.s3 import s3_multipart_test_lib
 from libs.s3 import CMN_CFG
-
+from libs.s3.s3_common_test_lib import create_bucket_put_get_objects
 
 class TestObjectWorkflowOperations:
     """Object Workflow Operations Testsuite."""
@@ -55,7 +52,7 @@ class TestObjectWorkflowOperations:
         self.s3_test_obj = s3_test_lib.S3TestLib()
         self.s3_cmd_obj = s3_cmd_test_lib.S3CmdTestLib()
         self.s3_mp_obj = s3_multipart_test_lib.S3MultipartTestLib()
-        self.system_random = secrets.SystemRandom()
+        self.randstr = system_utils.random_string_generator()
         self.buckets_list = list()
         self.bkt_name_prefix = "obj-workflow-bkt"
         self.bucket_name = "{0}{1}".format(self.bkt_name_prefix, time.perf_counter_ns())
@@ -80,70 +77,6 @@ class TestObjectWorkflowOperations:
             resp = self.s3_test_obj.delete_bucket(bucket_name=bucket_name, force=True)
             assert_utils.assert_true(resp[0], resp[1])
         self.log.info("ENDED: teardown method")
-
-    def create_bucket_put_objects(self, bucket_name, object_count):
-        """
-        Function will create a bucket with specified name and uploads.
-
-        given no of objects to the bucket.
-        :param str bucket_name: Name of a bucket to be created.
-        :param int object_count: No of objects to be uploaded into the bucket.
-        :return: List of objects uploaded to bucket.
-        :rtype: list
-        """
-        obj_list = []
-        self.log.info("Step 1: Creating a bucket with name %s", bucket_name)
-        resp = self.s3_test_obj.create_bucket(bucket_name)
-        assert resp[0], resp[1]
-        assert resp[1] == bucket_name, resp[0]
-        self.log.info("Step 1: Created a bucket with name %s", bucket_name)
-        self.log.info("Step 2: Uploading %s objects to the bucket ",  object_count)
-        for cnt in range(object_count):
-            obj_name = f"{self.obj_name_prefix}{cnt}"
-            system_utils.create_file(self.file_path, S3_OBJ_TST["s3_object"]["mb_count"])
-            resp = self.s3_test_obj.put_object(
-                bucket_name,
-                obj_name,
-                self.file_path)
-            assert resp[0], resp[1]
-            obj_list.append(obj_name)
-        self.log.info("Step 2: Uploaded %s objects to the bucket ", object_count)
-
-        return obj_list
-
-    def create_bucket_put_get_object(self, bucket_name, obj_key_name, file_path, mb_count):
-        """
-        Function creates a bucket and uploads an object
-        and then retrieves object from specified S3 bucket.
-
-        :param bucket_name: Name of bucket to be created.
-        :param obj_key_name: Key name of an object.
-        :param file_path: Path of the file to be created and uploaded to bucket.
-        :param mb_count: Size of file in MBs.
-        """
-        if isinstance(obj_key_name, list):
-            for key in obj_key_name:
-                resp = self.s3_test_obj.create_bucket_put_object(
-                    bucket_name, key, file_path, mb_count)
-                assert resp[0], resp[1]
-                resp = self.s3_test_obj.get_object(
-                    bucket_name, key)
-                assert resp[0], resp[1]
-                self.log.info(
-                    "GET operation successful for object %s from bucket %s",
-                    key, bucket_name)
-                resp = self.s3_test_obj.delete_bucket(self.bucket_name, force=True)
-                assert resp[0], resp[1]
-        else:
-            resp = self.s3_test_obj.create_bucket_put_object(
-                bucket_name, obj_key_name, file_path, mb_count)
-            assert resp[0], resp[1]
-            resp = self.s3_test_obj.get_object(
-                bucket_name, obj_key_name)
-            assert resp[0], resp[1]
-            self.log.info(
-                "GET operation successful for object %s from bucket %s",
-                obj_key_name, bucket_name)
 
     @pytest.mark.parallel
     @pytest.mark.s3_ops
@@ -645,8 +578,10 @@ class TestObjectWorkflowOperations:
             "STARTED: Test Delete objects which exists with verbose mode .")
         cfg_7653 = S3_OBJ_TST["test_7653"]
         bucket_name = self.bucket_name
-        obj_list = self.create_bucket_put_objects(
-            bucket_name, cfg_7653["no_of_objects"])
+        obj_list = create_bucket_put_get_objects(
+            bucket_name, cfg_7653["no_of_objects"], obj_name_prefix=self.obj_name_prefix,
+            file_path=self.file_path, mb_count=S3_OBJ_TST["s3_object"]["mb_count"],
+            s3_testobj=self.s3_test_obj)
         self.log.info(
             "Step 3: Deleting %s objects from bucket",
             cfg_7653["no_of_objects"])
@@ -678,8 +613,10 @@ class TestObjectWorkflowOperations:
             "which doesn't exists as well with quiet mode.")
         cfg_7655 = S3_OBJ_TST["test_7655"]
         bucket_name = self.bucket_name
-        obj_list = self.create_bucket_put_objects(
-            bucket_name, cfg_7655["no_of_objects"])
+        obj_list = create_bucket_put_get_objects(
+            bucket_name, cfg_7655["no_of_objects"], obj_name_prefix=self.obj_name_prefix,
+            file_path=self.file_path, mb_count=S3_OBJ_TST["s3_object"]["mb_count"],
+            s3_testobj=self.s3_test_obj)
         # Adding a dummy object to the object list which isn't uploaded to
         # bucket
         obj_list.append(self.obj_name_prefix + str(time.perf_counter_ns()))
@@ -713,8 +650,10 @@ class TestObjectWorkflowOperations:
         self.log.info("STARTED: Delete objects and mention 1001 objects.")
         cfg_7656 = S3_OBJ_TST["test_7656"]
         bucket_name = self.bucket_name
-        obj_list = self.create_bucket_put_objects(
-            bucket_name, cfg_7656["no_of_objects"])
+        obj_list = create_bucket_put_get_objects(
+            bucket_name, cfg_7656["no_of_objects"], obj_name_prefix=self.obj_name_prefix,
+            file_path=self.file_path, mb_count=S3_OBJ_TST["s3_object"]["mb_count"],
+            s3_testobj=self.s3_test_obj)
         self.log.info(
             "Step 3: Deleting %s objects from a bucket",
             cfg_7656["del_obj_cnt"])
@@ -742,8 +681,10 @@ class TestObjectWorkflowOperations:
         self.log.info("STARTED: Delete objects and mention 1000 objects.")
         cfg_7657 = S3_OBJ_TST["test_7657"]
         bucket_name = self.bucket_name
-        obj_list = self.create_bucket_put_objects(
-            bucket_name, cfg_7657["no_of_objects"])
+        obj_list = create_bucket_put_get_objects(
+            bucket_name, cfg_7657["no_of_objects"], obj_name_prefix=self.obj_name_prefix,
+            file_path=self.file_path, mb_count=S3_OBJ_TST["s3_object"]["mb_count"],
+            s3_testobj=self.s3_test_obj)
         self.log.info(
             "Step 3: Deleting %s objects from a bucket",
             cfg_7657["del_obj_cnt"])
@@ -766,7 +707,6 @@ class TestObjectWorkflowOperations:
         self.buckets_list.append(self.bucket_name)
         self.log.info("ENDED: Delete objects and mention 1000 objects.")
 
-    @pytest.mark.parallel
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-45504")
@@ -775,19 +715,17 @@ class TestObjectWorkflowOperations:
         self.log.info(
             "STARTED: Test GET operation for object with key name consisting "
             "of 1024 bytes")
-        obj_key_name = "".join(
-            random.choices(
-                f"{string.ascii_letters}{string.digits}",
-                k=S3_OBJ_TST["test_8547"]["obj_key_length"]))
-        self.create_bucket_put_get_object(
-            self.bucket_name, obj_key_name, self.file_path,
-            S3_OBJ_TST["s3_object"]["mb_count"])
+        obj_key_lst = [
+            system_utils.random_string_generator(
+                S3_OBJ_TST["test_8547"]["obj_key_length"])]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
         self.buckets_list.append(self.bucket_name)
         self.log.info(
             "ENDED: Test GET operation for object with key name consisting "
             "of 1024 bytes")
 
-    @pytest.mark.parallel
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-45506")
@@ -796,16 +734,15 @@ class TestObjectWorkflowOperations:
         self.log.info(
             "STARTED: Test GET operation for object with key name consisting "
             "of prefix and delimiter")
-        obj_key_name = "Finance/statements"
-        self.create_bucket_put_get_object(
-            self.bucket_name, obj_key_name, self.file_path,
-            S3_OBJ_TST["s3_object"]["mb_count"])
+        obj_key_lst = [f"{self.randstr}/{self.randstr}"]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
         self.buckets_list.append(self.bucket_name)
         self.log.info(
             "ENDED: Test GET operation for object with key name consisting "
             "of prefix and delimiter")
 
-    @pytest.mark.parallel
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-45507")
@@ -814,19 +751,15 @@ class TestObjectWorkflowOperations:
         self.log.info(
             "STARTED: Test GET operation for object with key name consisting "
             "of alphanumeric chars")
-        count_limit = self.system_random.randrange(4,10)
-        letters = "".join(random.choices(string.ascii_letters, k=count_limit))
-        digits = "".join(random.choices(string.digits, k=count_limit))
-        obj_key_name = f"{letters}{digits}"
-        self.create_bucket_put_get_object(
-            self.bucket_name, obj_key_name, self.file_path,
-            S3_OBJ_TST["s3_object"]["mb_count"])
+        obj_key_lst = [f"{self.randstr}"]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
         self.buckets_list.append(self.bucket_name)
         self.log.info(
             "ENDED: Test GET operation for object with key name consisting "
             "of alphanumeric chars")
 
-    @pytest.mark.parallel
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-45508")
@@ -835,15 +768,17 @@ class TestObjectWorkflowOperations:
         self.log.info(
             "STARTED: Test GET operation for object with key name consisting "
             "of underscore(_)")
-        obj_key_name = ["_objworkflow", "objworkflow_", "_objworkflow_", "obj_workflow"]
-        self.create_bucket_put_get_object(
-            self.bucket_name, obj_key_name, self.file_path,
-            S3_OBJ_TST["s3_object"]["mb_count"])
+        obj_key_lst = [
+            f"_{self.randstr}", f"{self.randstr}_", f"_{self.randstr}_",
+            f"{self.randstr}_{self.randstr}"]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
+        self.buckets_list.append(self.bucket_name)
         self.log.info(
             "ENDED: Test GET operation for object with key name consisting "
             "of underscore(_)")
 
-    @pytest.mark.parallel
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-45509")
@@ -852,15 +787,17 @@ class TestObjectWorkflowOperations:
         self.log.info(
             "STARTED: Test GET operation for object with key name consisting "
             "of Exclamation point(!)")
-        obj_key_name = ["!objworkflow", "objworkflow!", "!objworkflow!", "obj!workflow"]
-        self.create_bucket_put_get_object(
-            self.bucket_name, obj_key_name, self.file_path,
-            S3_OBJ_TST["s3_object"]["mb_count"])
+        obj_key_lst = [
+            f"!{self.randstr}", f"{self.randstr}!", f"!{self.randstr}!",
+            f"{self.randstr}!{self.randstr}"]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
+        self.buckets_list.append(self.bucket_name)
         self.log.info(
             "ENDED: Test GET operation for object with key name consisting "
             "of Exclamation point(!)")
 
-    @pytest.mark.parallel
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-45511")
@@ -869,15 +806,17 @@ class TestObjectWorkflowOperations:
         self.log.info(
             "STARTED: Test GET operation for object with key name consisting "
             "of Hyphen(-)")
-        obj_key_name = ["-objworkflow", "objworkflow-", "-objworkflow-", "obj-workflow"]
-        self.create_bucket_put_get_object(
-            self.bucket_name, obj_key_name, self.file_path,
-            S3_OBJ_TST["s3_object"]["mb_count"])
+        obj_key_lst = [
+            f"-{self.randstr}", f"{self.randstr}-", f"-{self.randstr}-",
+            f"{self.randstr}-{self.randstr}"]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
+        self.buckets_list.append(self.bucket_name)
         self.log.info(
             "ENDED: Test GET operation for object with key name consisting "
             "of Hyphen(-)")
 
-    @pytest.mark.parallel
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-45512")
@@ -886,15 +825,17 @@ class TestObjectWorkflowOperations:
         self.log.info(
             "STARTED: Test GET operation for object with key name consisting "
             "of Period(.)")
-        obj_key_name = [".objworkflow", "objworkflow.", ".objworkflow.", "obj.workflow"]
-        self.create_bucket_put_get_object(
-            self.bucket_name, obj_key_name, self.file_path,
-            S3_OBJ_TST["s3_object"]["mb_count"])
+        obj_key_lst = [
+            f".{self.randstr}", f"{self.randstr}.", f".{self.randstr}.",
+            f"{self.randstr}.{self.randstr}"]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
+        self.buckets_list.append(self.bucket_name)
         self.log.info(
             "ENDED: Test GET operation for object with key name consisting "
             "of Period(.)")
 
-    @pytest.mark.parallel
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-45513")
@@ -903,15 +844,17 @@ class TestObjectWorkflowOperations:
         self.log.info(
             "STARTED: Test GET operation for object with key name consisting "
             "of Single quote(')")
-        obj_key_name = ["'objworkflow", "objworkflow'", "'objworkflow'", "obj'workflow"]
-        self.create_bucket_put_get_object(
-            self.bucket_name, obj_key_name, self.file_path,
-            S3_OBJ_TST["s3_object"]["mb_count"])
+        obj_key_lst = [
+            f"'{self.randstr}", f"{self.randstr}'", f"'{self.randstr}'",
+            f"{self.randstr}'{self.randstr}"]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
+        self.buckets_list.append(self.bucket_name)
         self.log.info(
             "ENDED: Test GET operation for object with key name consisting "
             "of Single quote(')")
 
-    @pytest.mark.parallel
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-45514")
@@ -920,15 +863,17 @@ class TestObjectWorkflowOperations:
         self.log.info(
             "STARTED: Test GET operation for object with key name consisting "
             "of Asterisk(*)")
-        obj_key_name = ["*objworkflow", "objworkflow*", "*objworkflow*", "obj*workflow"]
-        self.create_bucket_put_get_object(
-            self.bucket_name, obj_key_name, self.file_path,
-            S3_OBJ_TST["s3_object"]["mb_count"])
+        obj_key_lst = [
+            f"*{self.randstr}", f"{self.randstr}*", f"*{self.randstr}*",
+            f"{self.randstr}*{self.randstr}"]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
+        self.buckets_list.append(self.bucket_name)
         self.log.info(
             "ENDED: Test GET operation for object with key name consisting "
             "of Asterisk(*)")
 
-    @pytest.mark.parallel
     @pytest.mark.s3_ops
     @pytest.mark.s3_object_ops
     @pytest.mark.tags("TEST-45515")
@@ -938,11 +883,51 @@ class TestObjectWorkflowOperations:
         self.log.info(
             "STARTED: Test GET operation for object with key name consisting of "
             "alphanumeric chars and special chars with prefix and delimiter")
-        obj_key_name = [
-            "My.family_photos-2014/jan/myvacation1.jpg", "videos/2014/birthday/video1.wmv"]
-        self.create_bucket_put_get_object(
-            self.bucket_name, obj_key_name, self.file_path,
-            S3_OBJ_TST["s3_object"]["mb_count"])
+        obj_key_lst = [
+            f"'{self.randstr}.{self.randstr}_{self.randstr}-{self.randstr}/{self.randstr}'",
+            f"{self.randstr}*{self.randstr}({self.randstr}){self.randstr}!"]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
+        self.buckets_list.append(self.bucket_name)
         self.log.info(
             "ENDED: Test GET operation for object with key name consisting of "
             "alphanumeric chars and special chars with prefix and delimiter")
+
+    @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
+    @pytest.mark.tags("TEST-47109")
+    def test_47109(self):
+        """Test GET operation for object with key name consisting of Open parenthesis(()"""
+        self.log.info(
+            "STARTED: Test GET operation for object with key name consisting of "
+            "Open parenthesis(()")
+        obj_key_lst = [
+            f"({self.randstr}", f"{self.randstr}(", f"({self.randstr}(",
+            f"{self.randstr}({self.randstr}"]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
+        self.buckets_list.append(self.bucket_name)
+        self.log.info(
+            "ENDED: Test GET operation for object with key name consisting of "
+            "Open parenthesis(()")
+
+    @pytest.mark.s3_ops
+    @pytest.mark.s3_object_ops
+    @pytest.mark.tags("TEST-47110")
+    def test_47110(self):
+        """Test GET operation for object with key name consisting of Close parenthesis())"""
+        self.log.info(
+            "STARTED: Test GET operation for object with key name consisting of "
+            "Close parenthesis())")
+        obj_key_lst = [
+            f"){self.randstr}", f"{self.randstr})", f"){self.randstr})",
+            f"{self.randstr}){self.randstr}"]
+        create_bucket_put_get_objects(
+            self.bucket_name, obj_list=obj_key_lst, file_path=self.file_path,
+            mb_count=S3_OBJ_TST["s3_object"]["mb_count"], s3_testobj=self.s3_test_obj)
+        self.buckets_list.append(self.bucket_name)
+        self.log.info(
+            "ENDED: Test GET operation for object with key name consisting of "
+            "Close parenthesis())")


### PR DESCRIPTION
# Problem Statement
Fix the failing multipart tests (TEST-44809 , TEST-44807) which were seen after running all parallel copy object testcases as part of below job .
Job - https://eos-jenkins.colo.seagate.com/job/QA/job/QA_R2_Single_Runner/2464/
Tests fixed : TEST-44809 , TEST-44807 .
Tests failed because etag validation was failing for source and destination copy object for multipart object . Etag for put-object and multipart uploaded/copied object always varies . Mutipart uploaded/copied object has an extension (-) in etag value followed by the no. of parts .
So now as part of fix , validating just the source and destination file content.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide