### PR TITLE
CORTX-33958 Fix failing multipart tests in parallel copy operations

### DIFF
--- a/libs/s3/s3_common_test_lib.py
+++ b/libs/s3/s3_common_test_lib.py
@@ -424,12 +424,7 @@ def validate_copy_content(src_bucket, src_object, dest_bucket, dest_object, **kw
     s3_test_object = kwargs.get("s3_testobj", "None")
     down_path1 = kwargs.get("down_path1", "None")
     down_path2 = kwargs.get("down_path2", "None")
-    src_resp = s3_test_object.object_info(src_bucket, src_object)
-    dest_resp = s3_test_object.object_info(dest_bucket, dest_object)
-    LOG.debug("ETag of source copy object %s", src_resp[1]["ETag"])
-    LOG.debug("ETag of destination copy object %s", dest_resp[1]["ETag"])
-    LOG.info("Compare ETag of source and destination copy object")
-    assert_utils.assert_equal(src_resp[1]["ETag"], dest_resp[1]["ETag"])
+    etag_verify = kwargs.get("etag_verify", True)
     LOG.info("Compare content of source and destination copy object")
     resp = s3_test_object.object_download(src_bucket, src_object, down_path1)
     assert_utils.assert_true(resp[0], resp[1])
@@ -438,8 +433,16 @@ def validate_copy_content(src_bucket, src_object, dest_bucket, dest_object, **kw
     assert_utils.assert_true(resp[0], resp[1])
     destchecksum = calculate_checksum(down_path2)
     assert_utils.assert_equal(srcchecksum, destchecksum, "Checksum match failed.")
+    LOG.info("Validated checksum of source and destination copy object")
+    if etag_verify:
+        src_resp = s3_test_object.object_info(src_bucket, src_object)
+        dest_resp = s3_test_object.object_info(dest_bucket, dest_object)
+        LOG.debug("ETag of source copy object %s", src_resp[1]["ETag"])
+        LOG.debug("ETag of destination copy object %s", dest_resp[1]["ETag"])
+        LOG.info("Compare ETag of source and destination copy object")
+        assert_utils.assert_equal(src_resp[1]["ETag"], dest_resp[1]["ETag"])
+        LOG.info("Validated ETag of source and destination copy object")
     LOG.info("Validated content of copy object")
-
 
 def list_objects_in_bucket(bucket, objects, s3_test_obj):
     """Assert if any of the given object not listed in given bucket"""

--- a/tests/s3/copy_object/test_parallel_copy_object.py
+++ b/tests/s3/copy_object/test_parallel_copy_object.py
@@ -275,7 +275,7 @@ class TestCopyObjects:
                               down_path2=self.downld_path2)
         validate_copy_content(self.src_bkt, self.key_mpobj1, self.src_bkt, self.key_obj4,
                               s3_testobj=self.s3_obj, down_path1=self.downld_path1,
-                              down_path2=self.downld_path2)
+                              down_path2=self.downld_path2, etag_verify=False)
         LOGGER.info("ENDED: Test Parallel put and copy on destination object "
                     "(simple and multipart source objects)")
 
@@ -299,8 +299,9 @@ class TestCopyObjects:
         self.parallel_copy_and_put_object((self.src_bkt, self.key_obj3, self.src_bkt,
                                           self.key_obj4), (self.src_bkt, self.key_obj3,
                                           self.file_path))
-        copy_obj_di_check(self.src_bkt, self.key_obj3, self.src_bkt, self.key_obj4,
-                          s3_testobj=self.s3_obj)
+        validate_copy_content(self.src_bkt, self.key_obj3, self.src_bkt, self.key_obj4,
+                              s3_testobj=self.s3_obj, down_path1=self.downld_path1,
+                              down_path2=self.downld_path2, etag_verify=False)
         LOGGER.info("All objects should be listed in relevant buckets")
         list_objects_in_bucket(bucket=self.src_bkt, objects=[self.key_obj1, self.key_obj2,
                            self.key_obj3, self.key_obj4], s3_test_obj=self.s3_obj)


### PR DESCRIPTION
Signed-off-by: Kapil Jinna <kapil.jinna@seagate.com>

# Problem Statement
Fix the failing multipart tests (TEST-44809 , TEST-44807) which were seen after running all parallel copy object testcases as part of below job .
Job - https://eos-jenkins.colo.seagate.com/job/QA/job/QA_R2_Single_Runner/2464/
Tests fixed : TEST-44809 , TEST-44807 .
Tests failed because etag validation was failing for source and destination copy object for multipart object . Etag for put-object and multipart uploaded/copied object always varies . Mutipart uploaded/copied object has an extension (-) in etag value followed by the no. of parts .
So now as part of fix , validating just the source and destination file content.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [ ] Attach test execution logs
-  [ ] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide