### PR TITLE
Hot fix for higher node config(>12)

### DIFF
--- a/config/prov/prov_test.yaml
+++ b/config/prov/prov_test.yaml
@@ -196,7 +196,7 @@ k8s_cortx_deploy:
   deploy_ha_timeout_key: "CORTX_DEPLOY_HA_TIMEOUT"
   deploy_server_timeout_key: "CORTX_DEPLOY_SERVER_TIMEOUT"
   deploy_ha_timeout_val: 1000
-  deploy_server_timeout_val: 1000
+  deploy_server_timeout_val: 1200
   timeout:
     pre-req: 120
     deploy: 7200

--- a/config/prov/prov_test.yaml
+++ b/config/prov/prov_test.yaml
@@ -194,7 +194,9 @@ k8s_cortx_deploy:
   destroy_setup_flag: "True"
   cortx_cluster_deploy_flag: "True"
   deploy_ha_timeout_key: "CORTX_DEPLOY_HA_TIMEOUT"
+  deploy_server_timeout_key: "CORTX_DEPLOY_SERVER_TIMEOUT"
   deploy_ha_timeout_val: 1000
+  deploy_server_timeout_val: 1000
   timeout:
     pre-req: 120
     deploy: 7200
@@ -287,6 +289,7 @@ k8s_cortx_deploy:
       limits:
         mem: '512Mi'
         cpu: '250m'
+  max_namespace_len: '20'
 test_basic_io:
   io_upper_limits:
     Kb: 130

--- a/libs/prov/prov_k8s_cortx_deploy.py
+++ b/libs/prov/prov_k8s_cortx_deploy.py
@@ -1583,9 +1583,9 @@ class ProvDeployK8sCortxLib:
                 response = []
                 time_taken = time.time() - start_time
                 LOGGER.info("#### Services online. Time Taken : %s", time_taken)
+                response.append(resp[0])
                 response.append(resp[1])
                 response.append(time_taken)
-                response.append(resp[0])
                 break
             response = [False, 'Timeout']
         LOGGER.info("hctl_status = %s", resp[1])

--- a/libs/prov/prov_k8s_cortx_deploy.py
+++ b/libs/prov/prov_k8s_cortx_deploy.py
@@ -1580,12 +1580,14 @@ class ProvDeployK8sCortxLib:
             resp = self.get_hctl_status(master_node_obj)
             LOGGER.debug("services status is %s, End Time is %s", resp[1], end_time)
             if resp[0]:
+                response = []
                 time_taken = time.time() - start_time
                 LOGGER.info("#### Services online. Time Taken : %s", time_taken)
                 response.append(resp[1])
                 response.append(time_taken)
+                response.append(resp[0])
                 break
-            response.extend([False, 'Timeout'])
+            response = [False, 'Timeout']
         LOGGER.info("hctl_status = %s", resp[1])
         return response
 

--- a/tests/prov/test_namespace_deployment.py
+++ b/tests/prov/test_namespace_deployment.py
@@ -167,6 +167,10 @@ class TestNamespaceDeployment:
                                            worker_node_list=self.worker_node_list,
                                            destroy_setup_flag=True,
                                            namespace=custom_namespace)
+        self.namespace = custom_namespace
+        self.log.info("Deleting the created namespace %s", custom_namespace)
+        resp = self.deploy_lc_obj.del_namespace(self.master_node_list[0], custom_namespace)
+        assert_utils.assert_true(resp)
         self.collect_sb = False
         self.destroy_flag = False
 

--- a/tests/prov/test_prov_pods_deployment.py
+++ b/tests/prov/test_prov_pods_deployment.py
@@ -102,7 +102,7 @@ class TestProvPodsDeployment:
             dix_parity=config['dix_parity'], dix_spare=config['dix_spare'],
             cvg_count=config['cvg_count'], data_disk_per_cvg=config['data_disk_per_cvg'],
             master_node_list=self.master_node_list, worker_node_list=self.worker_node_list,
-            destroy_setup_flag=False)
+            destroy_setup_flag=False, run_s3bench_workload_flag=False)
         resp = LogicalNode.get_all_pods(self.master_node_list[0],
                                         pod_prefix=constants.CONTROL_POD_NAME_PREFIX)
         assert_utils.assert_true(resp[0])
@@ -132,7 +132,7 @@ class TestProvPodsDeployment:
             dix_parity=config['dix_parity'], dix_spare=config['dix_spare'],
             cvg_count=config['cvg_count'], data_disk_per_cvg=config['data_disk_per_cvg'],
             master_node_list=self.master_node_list, worker_node_list=self.worker_node_list,
-            destroy_setup_flag=False)
+            run_s3bench_workload_flag=False, destroy_setup_flag=False)
         resp = LogicalNode.get_all_pods(self.master_node_list[0],
                                         pod_prefix=constants.POD_NAME_PREFIX)
         assert_utils.assert_true(resp[0])
@@ -162,7 +162,7 @@ class TestProvPodsDeployment:
             dix_parity=config['dix_parity'], dix_spare=config['dix_spare'],
             cvg_count=config['cvg_count'], data_disk_per_cvg=config['data_disk_per_cvg'],
             master_node_list=self.master_node_list, worker_node_list=self.worker_node_list,
-            destroy_setup_flag=False, s3_instance=2)
+            run_s3bench_workload_flag=False, destroy_setup_flag=False, s3_instance=2)
         resp = LogicalNode.get_all_pods(self.master_node_list[0],
                                         pod_prefix=constants.SERVER_POD_NAME_PREFIX)
         assert_utils.assert_true(resp[0])
@@ -192,7 +192,7 @@ class TestProvPodsDeployment:
             dix_parity=config['dix_parity'], dix_spare=config['dix_spare'],
             cvg_count=config['cvg_count'], data_disk_per_cvg=config['data_disk_per_cvg'],
             master_node_list=self.master_node_list, worker_node_list=self.worker_node_list,
-            destroy_setup_flag=False)
+            run_s3bench_workload_flag=False, destroy_setup_flag=False)
         resp = LogicalNode.get_all_pods(self.master_node_list[0],
                                         pod_prefix=constants.HA_POD_NAME_PREFIX)
         assert_utils.assert_true(resp[0])

--- a/tests/prov/test_prov_pods_deployment.py
+++ b/tests/prov/test_prov_pods_deployment.py
@@ -110,7 +110,7 @@ class TestProvPodsDeployment:
         self.log.info("Pod count is %s", len(resp))
         assert_utils.assert_equal(len(resp), 1)
         self.collect_sb = False
-        self.destroy_flag = False
+        self.destroy_flag = True
         self.log.info("===Test Completed===")
 
     @pytest.mark.lc
@@ -140,7 +140,7 @@ class TestProvPodsDeployment:
         self.log.info("Pod count is %s", len(resp))
         assert_utils.assert_equal(len(resp), config['cvg_count']*len(self.worker_node_list))
         self.collect_sb = False
-        self.destroy_flag = False
+        self.destroy_flag = True
         self.log.info("===Test Completed===")
 
     @pytest.mark.lc
@@ -162,7 +162,7 @@ class TestProvPodsDeployment:
             dix_parity=config['dix_parity'], dix_spare=config['dix_spare'],
             cvg_count=config['cvg_count'], data_disk_per_cvg=config['data_disk_per_cvg'],
             master_node_list=self.master_node_list, worker_node_list=self.worker_node_list,
-            destroy_setup_flag=False)
+            destroy_setup_flag=False, s3_instance=2)
         resp = LogicalNode.get_all_pods(self.master_node_list[0],
                                         pod_prefix=constants.SERVER_POD_NAME_PREFIX)
         assert_utils.assert_true(resp[0])
@@ -170,7 +170,7 @@ class TestProvPodsDeployment:
         self.log.info("Pod count is %s", len(resp))
         assert_utils.assert_equal(len(resp), 2*len(self.worker_node_list))
         self.collect_sb = False
-        self.destroy_flag = False
+        self.destroy_flag = True
         self.log.info("===Test Completed===")
 
     @pytest.mark.lc
@@ -200,7 +200,7 @@ class TestProvPodsDeployment:
         self.log.info("Pod count is %s", len(resp))
         assert_utils.assert_equal(len(resp), 1)
         self.collect_sb = False
-        self.destroy_flag = False
+        self.destroy_flag = True
         self.log.info("===Test Completed===")
 
     @pytest.mark.lc


### PR DESCRIPTION
# Problem Statement
- Added server pod timeout and fixed the destroy flag for F-87D test cases.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [ ] New/Affected tests are executed on Latest Build
-  [x] Attach test execution logs
[TEST-40442_TestNamespaceDeployment_20220914025404.log](https://github.com/Seagate/cortx-test/files/9565679/TEST-40442_TestNamespaceDeployment_20220914025404.log)
[TEST-40443_TestNamespaceDeployment_20220914023838.log](https://github.com/Seagate/cortx-test/files/9565682/TEST-40443_TestNamespaceDeployment_20220914023838.log)
-  [x] Collection tested and no collection error introduced (`pytest --local True --collect-only`)
[collections_log.txt](https://github.com/Seagate/cortx-test/files/9622375/collections_log.txt)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [ ] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide