### PR TITLE
CORTX-34257 : Get TE from JIRA and execute one by one

### DIFF
--- a/commons/utils/jira_utils.py
+++ b/commons/utils/jira_utils.py
@@ -161,14 +161,14 @@ class JiraTask:
             print("Returned code from xray jira request: {}".format(response.status_code))
         return test_details, te_tag
 
-    def get_test_plan_details(self, test_plan_id: str) -> [dict]:
+    def get_test_plan_details(self, test_plan: str) -> [dict]:
         """
         Summary: Get test executions from test plan.
 
         Description: Returns dictionary of test executions from test plan.
 
         Args:
-            test_plan_id:  (str): Test plan number in JIRA
+            test_plan:  (str): Test plan number in JIRA
 
         Returns:
             List of dictionaries
@@ -178,12 +178,12 @@ class JiraTask:
              "testEnvironments": ["515_full"]},
             ]
         """
-        jira_url = f'https://jts.seagate.com/rest/raven/1.0/api/testplan/' \
-                   f'{test_plan_id}/testexecution'
-        response = requests.get(jira_url, auth=(self.jira_id, self.jira_password))
-        if response.status_code == HTTPStatus.OK:
-            return response.json()
-        return response.text
+        jira_url = f'https://jts.seagate.com/rest/raven/1.0/api/testplan/{test_plan}/testexecution'
+        try:
+            response = self.http.get(jira_url, auth=self.auth, headers=self.headers)
+        except (JIRAError, requests.exceptions.RequestException) as fault:
+            raise EnvironmentError("Unable to access JIRA. Please check above errors.") from fault
+        return response.json()
 
     @staticmethod
     def get_test_list_from_test_plan(test_plan: str, username: str, password: str) -> [dict]:


### PR DESCRIPTION
# Problem Statement
- Make TE input optional and get TE list from the given Test Plan and execute it.
- Order TE to execute HA tests at last.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-  [x] New/Affected tests are executed on Latest Build
-  [x] Attach test execution logs
-  [x] Collection tested and no collection error introduced (`pytest --local True --collect-only`)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-  [x] If change in any common function, make sure to update all calls and execute all affected tests.

# Documentation
  Checklist for Author
-  [ ] Changes done to ReadMe / WIKI / Confluence page / Quick Start Guide